### PR TITLE
V0.1.2 Added mod configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,134 @@
 
 All notable changes to Strange Matter will be documented in this file.
 
+## [0.1.2] - 2025-10-09
+
+### Added
+
+#### Configuration
+- **Comprehensive configuration system** for all major mod features
+  - All configuration files are located in `config/strangematter-common.toml`
+  - Hot-reloadable configuration with `/reload` command
+
+##### World Generation
+- **Anomaly Spawn Rates**
+  - Enable/disable individual anomaly types
+  - Configure spawn rarity for each anomaly (1 in X chunks)
+  - Gravity Anomaly (default: 1/500)
+  - Temporal Bloom (default: 1/500)
+  - Warp Gate (default: 1/500)
+  - Energetic Rift (default: 1/500)
+  - Echoing Shadow (default: 1/500)
+  - Thoughtwell (default: 1/500)
+- **Ore Generation**
+  - Enable/disable Resonite ore generation
+  - Resonite ore veins per chunk (default: 3)
+- **Terrain Modification**
+  - Enable/disable Anomalous grass spawning
+  - Resonite ore spawn chance near anomalies (default: 15%)
+  - Anomaly shard ore spawn rates near anomalies
+
+##### Anomaly Effects
+- **Gravity Anomaly**
+  - Enable/disable levitation effects
+  - Levitation radius (default: 8 blocks)
+  - Levitation force strength (default: 0.1)
+  - Research points granted when scanned
+- **Temporal Bloom**
+  - Enable/disable temporal effects
+  - Effect radius (default: 8 blocks)
+  - Crop growth/de-growth stages (default: ±1-2)
+  - Crop effect cooldown (default: 5 seconds)
+  - Mob transformation cooldown (default: 10 seconds)
+  - Research points granted
+- **Energetic Rift**
+  - Enable/disable energy effects
+  - Zap radius (default: 6 blocks)
+  - Lightning rod radius (default: 8 blocks)
+  - Zap damage (default: 1.0 hearts)
+  - Zap cooldown (default: 2 seconds)
+  - Lightning rod cooldown (default: 10 seconds)
+  - Research points granted
+- **Warp Gate**
+  - Enable/disable teleportation effects
+  - Teleport radius (default: 2 blocks)
+  - Teleport cooldown (default: 5 seconds)
+  - Research points granted
+- **Echoing Shadow**
+  - Enable/disable shadow effects
+  - Effect radius
+  - Light absorption strength
+  - Mob spawn boost multiplier
+  - Research points granted
+- **Thoughtwell**
+  - Enable/disable cognitive effects
+  - Effect radius
+  - Confusion duration
+  - Research points granted
+
+##### Energy System
+- **Resonant Burner**
+  - Energy generation per tick (default: 20 RE/t)
+  - Internal energy storage (default: 10,000 RE)
+  - Energy transfer rate to adjacent blocks (default: 1000 RE/t)
+- **Resonance Condenser**
+  - Energy consumption per tick (default: 2 RE/t)
+  - Internal energy storage (default: 1000 RE)
+  - Shard generation progress speed (default: 15 ticks)
+- **Paradoxical Energy Cell**
+  - Energy transfer rate per tick (default: 1000 RE/t)
+- **Reality Forge**
+  - Crafting time (default: 100 ticks / 5 seconds)
+
+##### Research System
+- **Research Costs**
+  - Global multiplier for all research node costs
+  - Individual cost overrides for each of the 12 locked research nodes:
+    - Anomaly Resonator
+    - Resonance Condenser
+    - Containment Basics
+    - Reality Forge
+    - Warp Gun
+    - Stasis Projector
+    - Gravity Anomalies
+    - Temporal Anomalies
+    - Spatial Anomalies
+    - Energy Anomalies
+    - Shadow Anomalies
+    - Cognitive Anomalies
+
+##### Research Minigames
+- **Global Settings**
+  - Enable/disable minigame requirement (instant unlock when disabled)
+  - Instability mechanics:
+    - Decrease rate when all minigames stable (default: 0.004/tick)
+    - Base increase rate divided by number of active minigames (default: 0.001/tick)
+    - More active minigames = slower instability increase
+- **Energy Minigame (Wave Alignment)**
+  - Required alignment time (default: 100 ticks / 5 seconds)
+  - Drift delay before difficulty increases (default: 600 ticks / 30 seconds)
+  - Amplitude adjustment step size (default: 0.05)
+  - Period adjustment step size (default: 0.05)
+- **Space Minigame (Image Unwarp)**
+  - Stability threshold (default: 0.1, lower = harder)
+  - Drift delay (default: 100 ticks)
+  - Warp adjustment step size (default: 0.05)
+- **Time Minigame (Clock Speed Matching)**
+  - Speed difference threshold for stability (default: 0.15)
+  - Drift delay (default: 200 ticks)
+  - Speed adjustment step size (default: 0.1)
+- **Gravity Minigame (Balance Scale)**
+  - Balance threshold for stability (default: 0.1)
+  - Drift delay (default: 200 ticks)
+  - Uses continuous slider (no step adjustment)
+- **Shadow Minigame (Light Routing)**
+  - Alignment threshold for stability (default: 10.0)
+  - Drift delay (default: 200 ticks)
+  - Mirror rotation step size (default: 15 degrees)
+- **Cognition Minigame (Symbol Matching)**
+  - Symbol display duration (default: 100 ticks / 5 seconds)
+  - Number of symbols to match (default: 4, range: 2-8)
+
 ## [0.1.1] - 2025-10-08
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ mod_name=Strange Matter
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=0.1.1
+mod_version=0.1.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/hexvane/strangematter/Config.java
+++ b/src/main/java/com/hexvane/strangematter/Config.java
@@ -1,64 +1,895 @@
 package com.hexvane.strangematter;
 
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
-import net.minecraftforge.registries.ForgeRegistries;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-// An example config class. This is not required, but it's a good idea to have one to keep your config organized.
-// Demonstrates how to use Forge's config APIs
+/**
+ * Configuration file for Strange Matter mod.
+ * All configuration options are defined here and synced on load.
+ */
 @Mod.EventBusSubscriber(modid = StrangeMatterMod.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
-public class Config
-{
+public class Config {
     private static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
 
-    private static final ForgeConfigSpec.BooleanValue LOG_DIRT_BLOCK = BUILDER
-            .comment("Whether to log the dirt block on common setup")
-            .define("logDirtBlock", true);
+    // ========================================
+    // WORLD GENERATION - ANOMALY SPAWN RATES
+    // ========================================
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_GRAVITY_ANOMALY;
+    private static final ForgeConfigSpec.IntValue GRAVITY_ANOMALY_RARITY;
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_TEMPORAL_BLOOM;
+    private static final ForgeConfigSpec.IntValue TEMPORAL_BLOOM_RARITY;
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_WARP_GATE;
+    private static final ForgeConfigSpec.IntValue WARP_GATE_RARITY;
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_ENERGETIC_RIFT;
+    private static final ForgeConfigSpec.IntValue ENERGETIC_RIFT_RARITY;
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_ECHOING_SHADOW;
+    private static final ForgeConfigSpec.IntValue ECHOING_SHADOW_RARITY;
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_THOUGHTWELL;
+    private static final ForgeConfigSpec.IntValue THOUGHTWELL_RARITY;
 
-    private static final ForgeConfigSpec.IntValue MAGIC_NUMBER = BUILDER
-            .comment("A magic number")
-            .defineInRange("magicNumber", 42, 0, Integer.MAX_VALUE);
+    // ========================================
+    // WORLD GENERATION - ORE GENERATION
+    // ========================================
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_RESONITE_ORE;
+    private static final ForgeConfigSpec.IntValue RESONITE_ORE_VEINS_PER_CHUNK;
 
-    public static final ForgeConfigSpec.ConfigValue<String> MAGIC_NUMBER_INTRODUCTION = BUILDER
-            .comment("What you want the introduction message to be for the magic number")
-            .define("magicNumberIntroduction", "The magic number is... ");
+    // ========================================
+    // WORLD GENERATION - TERRAIN MODIFICATION
+    // ========================================
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_ANOMALOUS_GRASS;
+    private static final ForgeConfigSpec.DoubleValue RESONITE_ORE_SPAWN_CHANCE_NEAR_ANOMALY;
+    private static final ForgeConfigSpec.DoubleValue SHARD_ORE_SPAWN_CHANCE_NEAR_ANOMALY;
 
-    // a list of strings that are treated as resource locations for items
-    private static final ForgeConfigSpec.ConfigValue<List<? extends String>> ITEM_STRINGS = BUILDER
-            .comment("A list of items to log on common setup.")
-            .defineListAllowEmpty("items", List.of("minecraft:iron_ingot"), Config::validateItemName);
+    // ========================================
+    // ANOMALY EFFECTS CONFIG VALUES
+    // ========================================
+    
+    // Gravity Anomaly
+    private static final ForgeConfigSpec.BooleanValue ENABLE_GRAVITY_EFFECTS;
+    private static final ForgeConfigSpec.DoubleValue GRAVITY_LEVITATION_RADIUS;
+    private static final ForgeConfigSpec.DoubleValue GRAVITY_LEVITATION_FORCE;
+    private static final ForgeConfigSpec.IntValue GRAVITY_RESEARCH_POINTS;
+    
+    // Temporal Bloom
+    private static final ForgeConfigSpec.BooleanValue ENABLE_TEMPORAL_EFFECTS;
+    private static final ForgeConfigSpec.DoubleValue TEMPORAL_EFFECT_RADIUS;
+    private static final ForgeConfigSpec.IntValue TEMPORAL_CROP_GROWTH_STAGES;
+    private static final ForgeConfigSpec.IntValue TEMPORAL_CROP_COOLDOWN;
+    private static final ForgeConfigSpec.IntValue TEMPORAL_MOB_COOLDOWN;
+    private static final ForgeConfigSpec.IntValue TEMPORAL_RESEARCH_POINTS;
+    
+    // Energetic Rift
+    private static final ForgeConfigSpec.BooleanValue ENABLE_ENERGETIC_EFFECTS;
+    private static final ForgeConfigSpec.DoubleValue ENERGETIC_ZAP_RADIUS;
+    private static final ForgeConfigSpec.DoubleValue ENERGETIC_LIGHTNING_RADIUS;
+    private static final ForgeConfigSpec.DoubleValue ENERGETIC_ZAP_DAMAGE;
+    private static final ForgeConfigSpec.IntValue ENERGETIC_ZAP_COOLDOWN;
+    private static final ForgeConfigSpec.IntValue ENERGETIC_LIGHTNING_COOLDOWN;
+    private static final ForgeConfigSpec.IntValue ENERGETIC_RESEARCH_POINTS;
+    
+    // Warp Gate
+    private static final ForgeConfigSpec.BooleanValue ENABLE_WARP_EFFECTS;
+    private static final ForgeConfigSpec.DoubleValue WARP_TELEPORT_RADIUS;
+    private static final ForgeConfigSpec.IntValue WARP_TELEPORT_COOLDOWN;
+    private static final ForgeConfigSpec.IntValue WARP_RESEARCH_POINTS;
+    
+    // Echoing Shadow
+    private static final ForgeConfigSpec.BooleanValue ENABLE_SHADOW_EFFECTS;
+    private static final ForgeConfigSpec.DoubleValue SHADOW_EFFECT_RADIUS;
+    private static final ForgeConfigSpec.DoubleValue SHADOW_LIGHT_ABSORPTION;
+    private static final ForgeConfigSpec.DoubleValue SHADOW_MOB_SPAWN_BOOST;
+    private static final ForgeConfigSpec.IntValue SHADOW_RESEARCH_POINTS;
+    
+    // Thoughtwell
+    private static final ForgeConfigSpec.BooleanValue ENABLE_THOUGHTWELL_EFFECTS;
+    private static final ForgeConfigSpec.DoubleValue THOUGHTWELL_EFFECT_RADIUS;
+    private static final ForgeConfigSpec.IntValue THOUGHTWELL_CONFUSION_DURATION;
+    private static final ForgeConfigSpec.IntValue THOUGHTWELL_RESEARCH_POINTS;
+
+    // ========================================
+    // ENERGY SYSTEM CONFIG VALUES
+    // ========================================
+    
+    // Resonant Burner
+    private static final ForgeConfigSpec.IntValue RESONANT_BURNER_ENERGY_PER_TICK;
+    private static final ForgeConfigSpec.IntValue RESONANT_BURNER_ENERGY_STORAGE;
+    private static final ForgeConfigSpec.IntValue RESONANT_BURNER_TRANSFER_RATE;
+    
+    // Resonance Condenser
+    private static final ForgeConfigSpec.IntValue RESONANCE_CONDENSER_ENERGY_PER_TICK;
+    private static final ForgeConfigSpec.IntValue RESONANCE_CONDENSER_ENERGY_STORAGE;
+    private static final ForgeConfigSpec.IntValue RESONANCE_CONDENSER_PROGRESS_SPEED;
+    
+    // Paradoxical Energy Cell
+    private static final ForgeConfigSpec.IntValue PARADOXICAL_CELL_TRANSFER_RATE;
+    
+    // Reality Forge
+    private static final ForgeConfigSpec.IntValue REALITY_FORGE_CRAFT_TIME;
+
+    // ========================================
+    // RESEARCH SYSTEM CONFIG VALUES
+    // ========================================
+    
+    private static final ForgeConfigSpec.DoubleValue RESEARCH_COST_MULTIPLIER;
+    
+    // Individual research node costs
+    private static final ForgeConfigSpec.IntValue ANOMALY_RESONATOR_COST;
+    private static final ForgeConfigSpec.IntValue RESONANCE_CONDENSER_COST;
+    private static final ForgeConfigSpec.IntValue CONTAINMENT_BASICS_COST;
+    private static final ForgeConfigSpec.IntValue REALITY_FORGE_COST;
+    private static final ForgeConfigSpec.IntValue WARP_GUN_COST;
+    private static final ForgeConfigSpec.IntValue STASIS_PROJECTOR_COST;
+    private static final ForgeConfigSpec.IntValue GRAVITY_ANOMALIES_COST;
+    private static final ForgeConfigSpec.IntValue TEMPORAL_ANOMALIES_COST;
+    private static final ForgeConfigSpec.IntValue SPATIAL_ANOMALIES_COST;
+    private static final ForgeConfigSpec.IntValue ENERGY_ANOMALIES_COST;
+    private static final ForgeConfigSpec.IntValue SHADOW_ANOMALIES_COST;
+    private static final ForgeConfigSpec.IntValue COGNITIVE_ANOMALIES_COST;
+
+    // ========================================
+    // RESEARCH MINIGAMES CONFIG VALUES
+    // ========================================
+    
+    private static final ForgeConfigSpec.BooleanValue ENABLE_MINIGAMES;
+    
+    // Instability
+    private static final ForgeConfigSpec.DoubleValue INSTABILITY_DECREASE_RATE;
+    private static final ForgeConfigSpec.DoubleValue INSTABILITY_BASE_INCREASE_RATE;
+    
+    // Energy Minigame
+    private static final ForgeConfigSpec.IntValue ENERGY_REQUIRED_ALIGNMENT_TICKS;
+    private static final ForgeConfigSpec.IntValue ENERGY_DRIFT_DELAY_TICKS;
+    private static final ForgeConfigSpec.DoubleValue ENERGY_AMPLITUDE_STEP;
+    private static final ForgeConfigSpec.DoubleValue ENERGY_PERIOD_STEP;
+    
+    // Space Minigame
+    private static final ForgeConfigSpec.DoubleValue SPACE_STABILITY_THRESHOLD;
+    private static final ForgeConfigSpec.IntValue SPACE_DRIFT_DELAY_TICKS;
+    private static final ForgeConfigSpec.DoubleValue SPACE_WARP_ADJUSTMENT;
+    
+    // Time Minigame
+    private static final ForgeConfigSpec.DoubleValue TIME_SPEED_THRESHOLD;
+    private static final ForgeConfigSpec.IntValue TIME_DRIFT_DELAY_TICKS;
+    private static final ForgeConfigSpec.DoubleValue TIME_SPEED_ADJUSTMENT;
+    
+    // Gravity Minigame
+    private static final ForgeConfigSpec.DoubleValue GRAVITY_BALANCE_THRESHOLD;
+    private static final ForgeConfigSpec.IntValue GRAVITY_DRIFT_DELAY_TICKS;
+    
+    // Shadow Minigame
+    private static final ForgeConfigSpec.DoubleValue SHADOW_ALIGNMENT_THRESHOLD;
+    private static final ForgeConfigSpec.IntValue SHADOW_DRIFT_DELAY_TICKS;
+    private static final ForgeConfigSpec.DoubleValue SHADOW_ROTATION_STEP;
+    
+    // Cognition Minigame
+    private static final ForgeConfigSpec.IntValue COGNITION_MATCH_DURATION;
+    private static final ForgeConfigSpec.IntValue COGNITION_DIFFICULTY;
+
+    static {
+        BUILDER.comment("World Generation Settings").push("worldgen");
+        
+        // Anomaly Spawn Rates
+        BUILDER.comment("Anomaly Spawn Configuration",
+                "Enable/disable individual anomaly types and configure their spawn rarity.",
+                "Rarity values represent 1/N chance per chunk (higher = rarer).",
+                "For example, rarity of 500 means 1 in 500 chunks will spawn this anomaly.")
+                .push("anomalies");
+        
+        ENABLE_GRAVITY_ANOMALY = BUILDER
+                .comment("Enable Gravity Anomaly world generation")
+                .define("enableGravityAnomaly", true);
+        GRAVITY_ANOMALY_RARITY = BUILDER
+                .comment("Gravity Anomaly spawn rarity (1/N chance per chunk)")
+                .defineInRange("gravityAnomalyRarity", 500, 1, 100000);
+        
+        ENABLE_TEMPORAL_BLOOM = BUILDER
+                .comment("Enable Temporal Bloom world generation")
+                .define("enableTemporalBloom", true);
+        TEMPORAL_BLOOM_RARITY = BUILDER
+                .comment("Temporal Bloom spawn rarity (1/N chance per chunk)")
+                .defineInRange("temporalBloomRarity", 500, 1, 100000);
+        
+        ENABLE_WARP_GATE = BUILDER
+                .comment("Enable Warp Gate world generation")
+                .define("enableWarpGate", true);
+        WARP_GATE_RARITY = BUILDER
+                .comment("Warp Gate spawn rarity (1/N chance per chunk)")
+                .defineInRange("warpGateRarity", 500, 1, 100000);
+        
+        ENABLE_ENERGETIC_RIFT = BUILDER
+                .comment("Enable Energetic Rift world generation")
+                .define("enableEnergeticRift", true);
+        ENERGETIC_RIFT_RARITY = BUILDER
+                .comment("Energetic Rift spawn rarity (1/N chance per chunk)")
+                .defineInRange("energeticRiftRarity", 500, 1, 100000);
+        
+        ENABLE_ECHOING_SHADOW = BUILDER
+                .comment("Enable Echoing Shadow world generation")
+                .define("enableEchoingShadow", true);
+        ECHOING_SHADOW_RARITY = BUILDER
+                .comment("Echoing Shadow spawn rarity (1/N chance per chunk)")
+                .defineInRange("echoingShadowRarity", 500, 1, 100000);
+        
+        ENABLE_THOUGHTWELL = BUILDER
+                .comment("Enable Thoughtwell world generation")
+                .define("enableThoughtwell", true);
+        THOUGHTWELL_RARITY = BUILDER
+                .comment("Thoughtwell spawn rarity (1/N chance per chunk)")
+                .defineInRange("thoughtwellRarity", 500, 1, 100000);
+        
+        BUILDER.pop(); // anomalies
+        
+        // Ore Generation
+        BUILDER.comment("Ore Generation Configuration")
+                .push("ores");
+        
+        ENABLE_RESONITE_ORE = BUILDER
+                .comment("Enable Resonite Ore world generation")
+                .define("enableResoniteOre", true);
+        RESONITE_ORE_VEINS_PER_CHUNK = BUILDER
+                .comment("Number of Resonite Ore veins to attempt to generate per chunk")
+                .defineInRange("resoniteOreVeinsPerChunk", 3, 0, 64);
+        
+        BUILDER.pop(); // ores
+        
+        // Terrain Modification
+        BUILDER.comment("Terrain Modification Configuration",
+                "Settings for how anomalies modify the terrain around them")
+                .push("terrain");
+        
+        ENABLE_ANOMALOUS_GRASS = BUILDER
+                .comment("Enable Anomalous Grass generation around anomalies")
+                .define("enableAnomalousGrass", true);
+        RESONITE_ORE_SPAWN_CHANCE_NEAR_ANOMALY = BUILDER
+                .comment("Chance (0.0-1.0) for Resonite Ore to spawn near anomalies")
+                .defineInRange("resoniteOreSpawnChanceNearAnomaly", 0.5, 0.0, 1.0);
+        SHARD_ORE_SPAWN_CHANCE_NEAR_ANOMALY = BUILDER
+                .comment("Chance (0.0-1.0) for Anomaly Shard Ore to spawn near anomalies")
+                .defineInRange("shardOreSpawnChanceNearAnomaly", 0.2, 0.0, 1.0);
+        
+        BUILDER.pop(); // terrain
+        BUILDER.pop(); // worldgen
+        
+        // ========================================
+        // ANOMALY EFFECTS
+        // ========================================
+        
+        BUILDER.comment("Anomaly Effects Configuration",
+                "Control the behavior and strength of anomaly effects")
+                .push("anomaly_effects");
+        
+        // Gravity Anomaly
+        BUILDER.comment("Gravity Anomaly Effect Settings").push("gravity_anomaly");
+        ENABLE_GRAVITY_EFFECTS = BUILDER
+                .comment("Enable Gravity Anomaly effects (levitation)")
+                .define("enableEffects", true);
+        GRAVITY_LEVITATION_RADIUS = BUILDER
+                .comment("Levitation effect radius in blocks")
+                .defineInRange("levitationRadius", 8.0, 1.0, 32.0);
+        GRAVITY_LEVITATION_FORCE = BUILDER
+                .comment("Levitation force strength (higher = stronger)")
+                .defineInRange("levitationForce", 0.1, 0.01, 1.0);
+        GRAVITY_RESEARCH_POINTS = BUILDER
+                .comment("Research points granted when scanned")
+                .defineInRange("researchPoints", 10, 1, 1000);
+        BUILDER.pop();
+        
+        // Temporal Bloom
+        BUILDER.comment("Temporal Bloom Effect Settings").push("temporal_bloom");
+        ENABLE_TEMPORAL_EFFECTS = BUILDER
+                .comment("Enable Temporal Bloom effects (crop growth/mob transformation)")
+                .define("enableEffects", true);
+        TEMPORAL_EFFECT_RADIUS = BUILDER
+                .comment("Effect radius in blocks")
+                .defineInRange("effectRadius", 8.0, 1.0, 32.0);
+        TEMPORAL_CROP_GROWTH_STAGES = BUILDER
+                .comment("Maximum crop growth stages to add/remove (±N)")
+                .defineInRange("cropGrowthStages", 2, 1, 10);
+        TEMPORAL_CROP_COOLDOWN = BUILDER
+                .comment("Cooldown between crop effects in ticks (20 ticks = 1 second)")
+                .defineInRange("cropCooldown", 100, 1, 1200);
+        TEMPORAL_MOB_COOLDOWN = BUILDER
+                .comment("Cooldown between mob transformations in ticks (20 ticks = 1 second)")
+                .defineInRange("mobCooldown", 200, 1, 1200);
+        TEMPORAL_RESEARCH_POINTS = BUILDER
+                .comment("Research points granted when scanned")
+                .defineInRange("researchPoints", 10, 1, 1000);
+        BUILDER.pop();
+        
+        // Energetic Rift
+        BUILDER.comment("Energetic Rift Effect Settings").push("energetic_rift");
+        ENABLE_ENERGETIC_EFFECTS = BUILDER
+                .comment("Enable Energetic Rift effects (lightning/zapping)")
+                .define("enableEffects", true);
+        ENERGETIC_ZAP_RADIUS = BUILDER
+                .comment("Entity zap radius in blocks")
+                .defineInRange("zapRadius", 6.0, 1.0, 32.0);
+        ENERGETIC_LIGHTNING_RADIUS = BUILDER
+                .comment("Lightning rod detection radius in blocks")
+                .defineInRange("lightningRadius", 8.0, 1.0, 32.0);
+        ENERGETIC_ZAP_DAMAGE = BUILDER
+                .comment("Zap damage in half-hearts (2.0 = 1 heart)")
+                .defineInRange("zapDamage", 1.0, 0.5, 20.0);
+        ENERGETIC_ZAP_COOLDOWN = BUILDER
+                .comment("Cooldown between zaps in ticks (20 ticks = 1 second)")
+                .defineInRange("zapCooldown", 40, 1, 1200);
+        ENERGETIC_LIGHTNING_COOLDOWN = BUILDER
+                .comment("Cooldown between lightning strikes in ticks (20 ticks = 1 second)")
+                .defineInRange("lightningCooldown", 200, 1, 1200);
+        ENERGETIC_RESEARCH_POINTS = BUILDER
+                .comment("Research points granted when scanned")
+                .defineInRange("researchPoints", 10, 1, 1000);
+        BUILDER.pop();
+        
+        // Warp Gate
+        BUILDER.comment("Warp Gate Effect Settings").push("warp_gate");
+        ENABLE_WARP_EFFECTS = BUILDER
+                .comment("Enable Warp Gate effects (teleportation)")
+                .define("enableEffects", true);
+        WARP_TELEPORT_RADIUS = BUILDER
+                .comment("Teleport activation radius in blocks")
+                .defineInRange("teleportRadius", 2.0, 0.5, 16.0);
+        WARP_TELEPORT_COOLDOWN = BUILDER
+                .comment("Cooldown between teleports in ticks (20 ticks = 1 second)")
+                .defineInRange("teleportCooldown", 100, 1, 1200);
+        WARP_RESEARCH_POINTS = BUILDER
+                .comment("Research points granted when scanned")
+                .defineInRange("researchPoints", 10, 1, 1000);
+        BUILDER.pop();
+        
+        // Echoing Shadow
+        BUILDER.comment("Echoing Shadow Effect Settings").push("echoing_shadow");
+        ENABLE_SHADOW_EFFECTS = BUILDER
+                .comment("Enable Echoing Shadow effects (light absorption/mob spawning)")
+                .define("enableEffects", true);
+        SHADOW_EFFECT_RADIUS = BUILDER
+                .comment("Effect radius in blocks")
+                .defineInRange("effectRadius", 8.0, 1.0, 32.0);
+        SHADOW_LIGHT_ABSORPTION = BUILDER
+                .comment("Light absorption strength (0.0 = none, 1.0 = full)")
+                .defineInRange("lightAbsorption", 0.8, 0.0, 1.0);
+        SHADOW_MOB_SPAWN_BOOST = BUILDER
+                .comment("Mob spawn rate multiplier in shadow area")
+                .defineInRange("mobSpawnBoost", 2.0, 1.0, 10.0);
+        SHADOW_RESEARCH_POINTS = BUILDER
+                .comment("Research points granted when scanned")
+                .defineInRange("researchPoints", 10, 1, 1000);
+        BUILDER.pop();
+        
+        // Thoughtwell
+        BUILDER.comment("Thoughtwell Effect Settings").push("thoughtwell");
+        ENABLE_THOUGHTWELL_EFFECTS = BUILDER
+                .comment("Enable Thoughtwell effects (confusion)")
+                .define("enableEffects", true);
+        THOUGHTWELL_EFFECT_RADIUS = BUILDER
+                .comment("Effect radius in blocks")
+                .defineInRange("effectRadius", 6.0, 1.0, 32.0);
+        THOUGHTWELL_CONFUSION_DURATION = BUILDER
+                .comment("Confusion effect duration in ticks (20 ticks = 1 second)")
+                .defineInRange("confusionDuration", 100, 20, 1200);
+        THOUGHTWELL_RESEARCH_POINTS = BUILDER
+                .comment("Research points granted when scanned")
+                .defineInRange("researchPoints", 10, 1, 1000);
+        BUILDER.pop();
+        
+        BUILDER.pop(); // anomaly_effects
+        
+        // ========================================
+        // ENERGY SYSTEM
+        // ========================================
+        
+        BUILDER.comment("Energy System Configuration",
+                "Control energy generation, consumption, and storage for machines")
+                .push("energy");
+        
+        // Resonant Burner
+        BUILDER.comment("Resonant Burner Settings").push("resonant_burner");
+        RESONANT_BURNER_ENERGY_PER_TICK = BUILDER
+                .comment("Energy generated per tick (RE/t)")
+                .defineInRange("energyPerTick", 20, 1, 10000);
+        RESONANT_BURNER_ENERGY_STORAGE = BUILDER
+                .comment("Internal energy storage capacity (RE)")
+                .defineInRange("energyStorage", 10000, 100, 1000000);
+        RESONANT_BURNER_TRANSFER_RATE = BUILDER
+                .comment("Energy transfer rate to adjacent blocks per tick (RE/t)")
+                .defineInRange("transferRate", 1000, 1, 100000);
+        BUILDER.pop();
+        
+        // Resonance Condenser
+        BUILDER.comment("Resonance Condenser Settings").push("resonance_condenser");
+        RESONANCE_CONDENSER_ENERGY_PER_TICK = BUILDER
+                .comment("Energy consumed per tick (RE/t)")
+                .defineInRange("energyPerTick", 2, 1, 1000);
+        RESONANCE_CONDENSER_ENERGY_STORAGE = BUILDER
+                .comment("Internal energy storage capacity (RE)")
+                .defineInRange("energyStorage", 1000, 100, 100000);
+        RESONANCE_CONDENSER_PROGRESS_SPEED = BUILDER
+                .comment("Ticks required to progress shard generation (lower = faster)")
+                .defineInRange("progressSpeed", 15, 1, 600);
+        BUILDER.pop();
+        
+        // Paradoxical Energy Cell
+        BUILDER.comment("Paradoxical Energy Cell Settings").push("paradoxical_energy_cell");
+        PARADOXICAL_CELL_TRANSFER_RATE = BUILDER
+                .comment("Energy transfer rate to adjacent blocks per tick (RE/t)")
+                .defineInRange("transferRate", 1000, 1, 100000);
+        BUILDER.pop();
+        
+        // Reality Forge
+        BUILDER.comment("Reality Forge Settings").push("reality_forge");
+        REALITY_FORGE_CRAFT_TIME = BUILDER
+                .comment("Crafting time in ticks (20 ticks = 1 second)")
+                .defineInRange("craftTime", 100, 1, 1200);
+        BUILDER.pop();
+        
+        BUILDER.pop(); // energy
+        
+        // ========================================
+        // RESEARCH SYSTEM
+        // ========================================
+        
+        BUILDER.comment("Research System Configuration",
+                "Control research costs and progression")
+                .push("research");
+        
+        RESEARCH_COST_MULTIPLIER = BUILDER
+                .comment("Global multiplier for all research node costs (1.0 = default, 0.5 = half cost, 2.0 = double cost)")
+                .defineInRange("costMultiplier", 1.0, 0.0, 10.0);
+        
+        // Individual research node cost overrides (optional)
+        BUILDER.comment("Individual Research Node Costs",
+                "Override costs for specific research nodes. Set to -1 to use default values.",
+                "Each node can require multiple research types. Values are point costs.")
+                .push("node_costs");
+        
+        // Only configure nodes that have actual costs (locked nodes)
+        ANOMALY_RESONATOR_COST = BUILDER
+                .comment("Anomaly Resonator total cost (-1 for default: Energy 10, Space 10)")
+                .defineInRange("anomalyResonator", -1, -1, 10000);
+        
+        RESONANCE_CONDENSER_COST = BUILDER
+                .comment("Resonance Condenser total cost (-1 for default: Energy 25, Space 15)")
+                .defineInRange("resonanceCondenser", -1, -1, 10000);
+        
+        CONTAINMENT_BASICS_COST = BUILDER
+                .comment("Containment Basics total cost (-1 for default: Energy 20, Shadow 15)")
+                .defineInRange("containmentBasics", -1, -1, 10000);
+        
+        REALITY_FORGE_COST = BUILDER
+                .comment("Reality Forge total cost (-1 for default: Energy 5, Space 5, Time 5)")
+                .defineInRange("realityForge", -1, -1, 10000);
+        
+        WARP_GUN_COST = BUILDER
+                .comment("Warp Gun total cost (-1 for default: Space 15, Energy 10)")
+                .defineInRange("warpGun", -1, -1, 10000);
+        
+        STASIS_PROJECTOR_COST = BUILDER
+                .comment("Stasis Projector total cost (-1 for default: Gravity 5, Time 5)")
+                .defineInRange("stasisProjector", -1, -1, 10000);
+        
+        GRAVITY_ANOMALIES_COST = BUILDER
+                .comment("Gravity Anomalies research cost (-1 for default: Gravity 5)")
+                .defineInRange("gravityAnomalies", -1, -1, 10000);
+        
+        TEMPORAL_ANOMALIES_COST = BUILDER
+                .comment("Temporal Anomalies research cost (-1 for default: Time 5)")
+                .defineInRange("temporalAnomalies", -1, -1, 10000);
+        
+        SPATIAL_ANOMALIES_COST = BUILDER
+                .comment("Spatial Anomalies research cost (-1 for default: Space 5)")
+                .defineInRange("spatialAnomalies", -1, -1, 10000);
+        
+        ENERGY_ANOMALIES_COST = BUILDER
+                .comment("Energy Anomalies research cost (-1 for default: Energy 5)")
+                .defineInRange("energyAnomalies", -1, -1, 10000);
+        
+        SHADOW_ANOMALIES_COST = BUILDER
+                .comment("Shadow Anomalies research cost (-1 for default: Shadow 5)")
+                .defineInRange("shadowAnomalies", -1, -1, 10000);
+        
+        COGNITIVE_ANOMALIES_COST = BUILDER
+                .comment("Cognitive Anomalies research cost (-1 for default: Cognition 5)")
+                .defineInRange("cognitiveAnomalies", -1, -1, 10000);
+        
+        BUILDER.pop(); // node_costs
+        BUILDER.pop(); // research
+        
+        // ========================================
+        // RESEARCH MINIGAMES
+        // ========================================
+        
+        BUILDER.comment("Research Minigame Configuration",
+                "Control difficulty and behavior of research minigames")
+                .push("minigames");
+        
+        ENABLE_MINIGAMES = BUILDER
+                .comment("Enable minigame requirement (false = instant unlock when inserting research note)")
+                .define("enableMinigames", true);
+        
+        // Instability System
+        BUILDER.comment("Instability System Settings",
+                "More active minigames = SLOWER instability increase (more time to balance multiple aspects).")
+                .push("instability");
+        INSTABILITY_DECREASE_RATE = BUILDER
+                .comment("Instability decrease rate per tick when all minigames are stable")
+                .defineInRange("decreaseRate", 0.004, 0.0001, 0.1);
+        INSTABILITY_BASE_INCREASE_RATE = BUILDER
+                .comment("Base instability increase rate when minigames are unstable",
+                        "Actual rate = baseRate / number_of_active_minigames",
+                        "More active minigames = slower increase = more time to stabilize")
+                .defineInRange("baseIncreaseRate", 0.001, 0.0001, 0.1);
+        BUILDER.pop();
+        
+        // Energy Minigame
+        BUILDER.comment("Energy Minigame Settings (Wave Alignment)").push("energy");
+        ENERGY_REQUIRED_ALIGNMENT_TICKS = BUILDER
+                .comment("Ticks required to maintain alignment for success (20 ticks = 1 second)")
+                .defineInRange("requiredAlignmentTicks", 100, 20, 1200);
+        ENERGY_DRIFT_DELAY_TICKS = BUILDER
+                .comment("Ticks before parameters start drifting (increases difficulty over time)")
+                .defineInRange("driftDelayTicks", 600, 60, 2400);
+        ENERGY_AMPLITUDE_STEP = BUILDER
+                .comment("Amplitude adjustment step size per button press")
+                .defineInRange("amplitudeStep", 0.05, 0.01, 0.5);
+        ENERGY_PERIOD_STEP = BUILDER
+                .comment("Period adjustment step size per button press")
+                .defineInRange("periodStep", 0.05, 0.01, 0.5);
+        BUILDER.pop();
+        
+        // Space Minigame
+        BUILDER.comment("Space Minigame Settings (Image Unwarp)").push("space");
+        SPACE_STABILITY_THRESHOLD = BUILDER
+                .comment("How close to 0 warp is considered stable (lower = harder)")
+                .defineInRange("stabilityThreshold", 0.1, 0.01, 1.0);
+        SPACE_DRIFT_DELAY_TICKS = BUILDER
+                .comment("Ticks before warp starts drifting")
+                .defineInRange("driftDelayTicks", 100, 20, 1200);
+        SPACE_WARP_ADJUSTMENT = BUILDER
+                .comment("Warp adjustment step size per button press")
+                .defineInRange("warpAdjustment", 0.05, 0.01, 0.5);
+        BUILDER.pop();
+        
+        // Time Minigame
+        BUILDER.comment("Time Minigame Settings (Clock Speed Matching)").push("time");
+        TIME_SPEED_THRESHOLD = BUILDER
+                .comment("Speed difference threshold for stability (lower = harder)")
+                .defineInRange("speedThreshold", 0.15, 0.01, 1.0);
+        TIME_DRIFT_DELAY_TICKS = BUILDER
+                .comment("Ticks before speed starts drifting")
+                .defineInRange("driftDelayTicks", 200, 20, 1200);
+        TIME_SPEED_ADJUSTMENT = BUILDER
+                .comment("Speed adjustment step size per button press")
+                .defineInRange("speedAdjustment", 0.1, 0.01, 1.0);
+        BUILDER.pop();
+        
+        // Gravity Minigame
+        BUILDER.comment("Gravity Minigame Settings (Balance Scale)").push("gravity");
+        GRAVITY_BALANCE_THRESHOLD = BUILDER
+                .comment("Balance threshold for stability (lower = harder)")
+                .defineInRange("balanceThreshold", 0.1, 0.01, 1.0);
+        GRAVITY_DRIFT_DELAY_TICKS = BUILDER
+                .comment("Ticks before balance starts drifting")
+                .defineInRange("driftDelayTicks", 200, 20, 1200);
+        BUILDER.pop();
+        
+        // Shadow Minigame
+        BUILDER.comment("Shadow Minigame Settings (Light Routing)").push("shadow");
+        SHADOW_ALIGNMENT_THRESHOLD = BUILDER
+                .comment("Alignment threshold for stability (lower = harder)")
+                .defineInRange("alignmentThreshold", 10.0, 1.0, 50.0);
+        SHADOW_DRIFT_DELAY_TICKS = BUILDER
+                .comment("Ticks before mirrors start drifting")
+                .defineInRange("driftDelayTicks", 200, 20, 1200);
+        SHADOW_ROTATION_STEP = BUILDER
+                .comment("Mirror rotation step size per button press (degrees)")
+                .defineInRange("rotationStep", 15.0, 1.0, 90.0);
+        BUILDER.pop();
+        
+        // Cognition Minigame
+        BUILDER.comment("Cognition Minigame Settings (Symbol Matching)").push("cognition");
+        COGNITION_MATCH_DURATION = BUILDER
+                .comment("Ticks symbols stay visible before changing")
+                .defineInRange("matchDuration", 50, 20, 600);
+        COGNITION_DIFFICULTY = BUILDER
+                .comment("Number of symbols to match (higher = harder)")
+                .defineInRange("difficulty", 3, 2, 8);
+        BUILDER.pop();
+        
+        BUILDER.pop(); // minigames
+    }
 
     static final ForgeConfigSpec SPEC = BUILDER.build();
 
-    public static boolean logDirtBlock;
-    public static int magicNumber;
-    public static String magicNumberIntroduction;
-    public static Set<Item> items;
-
-    private static boolean validateItemName(final Object obj)
-    {
-        return obj instanceof final String itemName && ForgeRegistries.ITEMS.containsKey(new ResourceLocation(itemName));
-    }
+    // Public static fields to access config values
+    public static boolean enableGravityAnomaly;
+    public static int gravityAnomalyRarity;
+    
+    public static boolean enableTemporalBloom;
+    public static int temporalBloomRarity;
+    
+    public static boolean enableWarpGate;
+    public static int warpGateRarity;
+    
+    public static boolean enableEnergeticRift;
+    public static int energeticRiftRarity;
+    
+    public static boolean enableEchoingShadow;
+    public static int echoingShadowRarity;
+    
+    public static boolean enableThoughtwell;
+    public static int thoughtwellRarity;
+    
+    public static boolean enableResoniteOre;
+    public static int resoniteOreVeinsPerChunk;
+    
+    public static boolean enableAnomalousGrass;
+    public static double resoniteOreSpawnChanceNearAnomaly;
+    public static double shardOreSpawnChanceNearAnomaly;
+    
+    // Anomaly effects
+    // Gravity Anomaly
+    public static boolean enableGravityEffects;
+    public static double gravityLevitationRadius;
+    public static double gravityLevitationForce;
+    public static int gravityResearchPoints;
+    
+    // Temporal Bloom
+    public static boolean enableTemporalEffects;
+    public static double temporalEffectRadius;
+    public static int temporalCropGrowthStages;
+    public static int temporalCropCooldown;
+    public static int temporalMobCooldown;
+    public static int temporalResearchPoints;
+    
+    // Energetic Rift
+    public static boolean enableEnergeticEffects;
+    public static double energeticZapRadius;
+    public static double energeticLightningRadius;
+    public static double energeticZapDamage;
+    public static int energeticZapCooldown;
+    public static int energeticLightningCooldown;
+    public static int energeticResearchPoints;
+    
+    // Warp Gate
+    public static boolean enableWarpEffects;
+    public static double warpTeleportRadius;
+    public static int warpTeleportCooldown;
+    public static int warpResearchPoints;
+    
+    // Echoing Shadow
+    public static boolean enableShadowEffects;
+    public static double shadowEffectRadius;
+    public static double shadowLightAbsorption;
+    public static double shadowMobSpawnBoost;
+    public static int shadowResearchPoints;
+    
+    // Thoughtwell
+    public static boolean enableThoughtwellEffects;
+    public static double thoughtwellEffectRadius;
+    public static int thoughtwellConfusionDuration;
+    public static int thoughtwellResearchPoints;
+    
+    // Energy system
+    // Resonant Burner
+    public static int resonantBurnerEnergyPerTick;
+    public static int resonantBurnerEnergyStorage;
+    public static int resonantBurnerTransferRate;
+    
+    // Resonance Condenser
+    public static int resonanceCondenserEnergyPerTick;
+    public static int resonanceCondenserEnergyStorage;
+    public static int resonanceCondenserProgressSpeed;
+    
+    // Paradoxical Energy Cell
+    public static int paradoxicalCellTransferRate;
+    
+    // Reality Forge
+    public static int realityForgeCraftTime;
+    
+    // Research system
+    public static double researchCostMultiplier;
+    
+    // Individual research node costs
+    public static int anomalyResonatorCost;
+    public static int resonanceCondenserCost;
+    public static int containmentBasicsCost;
+    public static int realityForgeCost;
+    public static int warpGunCost;
+    public static int stasisProjectorCost;
+    public static int gravityAnomaliesCost;
+    public static int temporalAnomaliesCost;
+    public static int spatialAnomaliesCost;
+    public static int energyAnomaliesCost;
+    public static int shadowAnomaliesCost;
+    public static int cognitiveAnomaliesCost;
+    
+    // Minigames
+    public static boolean enableMinigames;
+    
+    // Instability
+    public static double instabilityDecreaseRate;
+    public static double instabilityBaseIncreaseRate;
+    
+    // Energy Minigame
+    public static int energyRequiredAlignmentTicks;
+    public static int energyDriftDelayTicks;
+    public static double energyAmplitudeStep;
+    public static double energyPeriodStep;
+    
+    // Space Minigame
+    public static double spaceStabilityThreshold;
+    public static int spaceDriftDelayTicks;
+    public static double spaceWarpAdjustment;
+    
+    // Time Minigame
+    public static double timeSpeedThreshold;
+    public static int timeDriftDelayTicks;
+    public static double timeSpeedAdjustment;
+    
+    // Gravity Minigame
+    public static double gravityBalanceThreshold;
+    public static int gravityDriftDelayTicks;
+    
+    // Shadow Minigame
+    public static double shadowAlignmentThreshold;
+    public static int shadowDriftDelayTicks;
+    public static double shadowRotationStep;
+    
+    // Cognition Minigame
+    public static int cognitionMatchDuration;
+    public static int cognitionDifficulty;
 
     @SubscribeEvent
-    static void onLoad(final ModConfigEvent event)
-    {
-        logDirtBlock = LOG_DIRT_BLOCK.get();
-        magicNumber = MAGIC_NUMBER.get();
-        magicNumberIntroduction = MAGIC_NUMBER_INTRODUCTION.get();
-
-        // convert the list of strings into a set of items
-        items = ITEM_STRINGS.get().stream()
-                .map(itemName -> ForgeRegistries.ITEMS.getValue(new ResourceLocation(itemName)))
-                .collect(Collectors.toSet());
+    static void onLoad(final ModConfigEvent event) {
+        // Anomaly spawn rates
+        enableGravityAnomaly = ENABLE_GRAVITY_ANOMALY.get();
+        gravityAnomalyRarity = GRAVITY_ANOMALY_RARITY.get();
+        
+        enableTemporalBloom = ENABLE_TEMPORAL_BLOOM.get();
+        temporalBloomRarity = TEMPORAL_BLOOM_RARITY.get();
+        
+        enableWarpGate = ENABLE_WARP_GATE.get();
+        warpGateRarity = WARP_GATE_RARITY.get();
+        
+        enableEnergeticRift = ENABLE_ENERGETIC_RIFT.get();
+        energeticRiftRarity = ENERGETIC_RIFT_RARITY.get();
+        
+        enableEchoingShadow = ENABLE_ECHOING_SHADOW.get();
+        echoingShadowRarity = ECHOING_SHADOW_RARITY.get();
+        
+        enableThoughtwell = ENABLE_THOUGHTWELL.get();
+        thoughtwellRarity = THOUGHTWELL_RARITY.get();
+        
+        // Ore generation
+        enableResoniteOre = ENABLE_RESONITE_ORE.get();
+        resoniteOreVeinsPerChunk = RESONITE_ORE_VEINS_PER_CHUNK.get();
+        
+        // Terrain modification
+        enableAnomalousGrass = ENABLE_ANOMALOUS_GRASS.get();
+        resoniteOreSpawnChanceNearAnomaly = RESONITE_ORE_SPAWN_CHANCE_NEAR_ANOMALY.get();
+        shardOreSpawnChanceNearAnomaly = SHARD_ORE_SPAWN_CHANCE_NEAR_ANOMALY.get();
+        
+        // Anomaly effects
+        // Gravity Anomaly
+        enableGravityEffects = ENABLE_GRAVITY_EFFECTS.get();
+        gravityLevitationRadius = GRAVITY_LEVITATION_RADIUS.get();
+        gravityLevitationForce = GRAVITY_LEVITATION_FORCE.get();
+        gravityResearchPoints = GRAVITY_RESEARCH_POINTS.get();
+        
+        // Temporal Bloom
+        enableTemporalEffects = ENABLE_TEMPORAL_EFFECTS.get();
+        temporalEffectRadius = TEMPORAL_EFFECT_RADIUS.get();
+        temporalCropGrowthStages = TEMPORAL_CROP_GROWTH_STAGES.get();
+        temporalCropCooldown = TEMPORAL_CROP_COOLDOWN.get();
+        temporalMobCooldown = TEMPORAL_MOB_COOLDOWN.get();
+        temporalResearchPoints = TEMPORAL_RESEARCH_POINTS.get();
+        
+        // Energetic Rift
+        enableEnergeticEffects = ENABLE_ENERGETIC_EFFECTS.get();
+        energeticZapRadius = ENERGETIC_ZAP_RADIUS.get();
+        energeticLightningRadius = ENERGETIC_LIGHTNING_RADIUS.get();
+        energeticZapDamage = ENERGETIC_ZAP_DAMAGE.get();
+        energeticZapCooldown = ENERGETIC_ZAP_COOLDOWN.get();
+        energeticLightningCooldown = ENERGETIC_LIGHTNING_COOLDOWN.get();
+        energeticResearchPoints = ENERGETIC_RESEARCH_POINTS.get();
+        
+        // Warp Gate
+        enableWarpEffects = ENABLE_WARP_EFFECTS.get();
+        warpTeleportRadius = WARP_TELEPORT_RADIUS.get();
+        warpTeleportCooldown = WARP_TELEPORT_COOLDOWN.get();
+        warpResearchPoints = WARP_RESEARCH_POINTS.get();
+        
+        // Echoing Shadow
+        enableShadowEffects = ENABLE_SHADOW_EFFECTS.get();
+        shadowEffectRadius = SHADOW_EFFECT_RADIUS.get();
+        shadowLightAbsorption = SHADOW_LIGHT_ABSORPTION.get();
+        shadowMobSpawnBoost = SHADOW_MOB_SPAWN_BOOST.get();
+        shadowResearchPoints = SHADOW_RESEARCH_POINTS.get();
+        
+        // Thoughtwell
+        enableThoughtwellEffects = ENABLE_THOUGHTWELL_EFFECTS.get();
+        thoughtwellEffectRadius = THOUGHTWELL_EFFECT_RADIUS.get();
+        thoughtwellConfusionDuration = THOUGHTWELL_CONFUSION_DURATION.get();
+        thoughtwellResearchPoints = THOUGHTWELL_RESEARCH_POINTS.get();
+        
+        // Energy system
+        // Resonant Burner
+        resonantBurnerEnergyPerTick = RESONANT_BURNER_ENERGY_PER_TICK.get();
+        resonantBurnerEnergyStorage = RESONANT_BURNER_ENERGY_STORAGE.get();
+        resonantBurnerTransferRate = RESONANT_BURNER_TRANSFER_RATE.get();
+        
+        // Resonance Condenser
+        resonanceCondenserEnergyPerTick = RESONANCE_CONDENSER_ENERGY_PER_TICK.get();
+        resonanceCondenserEnergyStorage = RESONANCE_CONDENSER_ENERGY_STORAGE.get();
+        resonanceCondenserProgressSpeed = RESONANCE_CONDENSER_PROGRESS_SPEED.get();
+        
+        // Paradoxical Energy Cell
+        paradoxicalCellTransferRate = PARADOXICAL_CELL_TRANSFER_RATE.get();
+        
+        // Reality Forge
+        realityForgeCraftTime = REALITY_FORGE_CRAFT_TIME.get();
+        
+        // Research system
+        researchCostMultiplier = RESEARCH_COST_MULTIPLIER.get();
+        
+        // Individual research node costs
+        anomalyResonatorCost = ANOMALY_RESONATOR_COST.get();
+        resonanceCondenserCost = RESONANCE_CONDENSER_COST.get();
+        containmentBasicsCost = CONTAINMENT_BASICS_COST.get();
+        realityForgeCost = REALITY_FORGE_COST.get();
+        warpGunCost = WARP_GUN_COST.get();
+        stasisProjectorCost = STASIS_PROJECTOR_COST.get();
+        gravityAnomaliesCost = GRAVITY_ANOMALIES_COST.get();
+        temporalAnomaliesCost = TEMPORAL_ANOMALIES_COST.get();
+        spatialAnomaliesCost = SPATIAL_ANOMALIES_COST.get();
+        energyAnomaliesCost = ENERGY_ANOMALIES_COST.get();
+        shadowAnomaliesCost = SHADOW_ANOMALIES_COST.get();
+        cognitiveAnomaliesCost = COGNITIVE_ANOMALIES_COST.get();
+        
+        // Minigames
+        enableMinigames = ENABLE_MINIGAMES.get();
+        
+        // Instability
+        instabilityDecreaseRate = INSTABILITY_DECREASE_RATE.get();
+        instabilityBaseIncreaseRate = INSTABILITY_BASE_INCREASE_RATE.get();
+        
+        // Energy Minigame
+        energyRequiredAlignmentTicks = ENERGY_REQUIRED_ALIGNMENT_TICKS.get();
+        energyDriftDelayTicks = ENERGY_DRIFT_DELAY_TICKS.get();
+        energyAmplitudeStep = ENERGY_AMPLITUDE_STEP.get();
+        energyPeriodStep = ENERGY_PERIOD_STEP.get();
+        
+        // Space Minigame
+        spaceStabilityThreshold = SPACE_STABILITY_THRESHOLD.get();
+        spaceDriftDelayTicks = SPACE_DRIFT_DELAY_TICKS.get();
+        spaceWarpAdjustment = SPACE_WARP_ADJUSTMENT.get();
+        
+        // Time Minigame
+        timeSpeedThreshold = TIME_SPEED_THRESHOLD.get();
+        timeDriftDelayTicks = TIME_DRIFT_DELAY_TICKS.get();
+        timeSpeedAdjustment = TIME_SPEED_ADJUSTMENT.get();
+        
+        // Gravity Minigame
+        gravityBalanceThreshold = GRAVITY_BALANCE_THRESHOLD.get();
+        gravityDriftDelayTicks = GRAVITY_DRIFT_DELAY_TICKS.get();
+        
+        // Shadow Minigame
+        shadowAlignmentThreshold = SHADOW_ALIGNMENT_THRESHOLD.get();
+        shadowDriftDelayTicks = SHADOW_DRIFT_DELAY_TICKS.get();
+        shadowRotationStep = SHADOW_ROTATION_STEP.get();
+        
+        // Cognition Minigame
+        cognitionMatchDuration = COGNITION_MATCH_DURATION.get();
+        cognitionDifficulty = COGNITION_DIFFICULTY.get();
     }
 }

--- a/src/main/java/com/hexvane/strangematter/block/BaseMachineBlockEntity.java
+++ b/src/main/java/com/hexvane/strangematter/block/BaseMachineBlockEntity.java
@@ -158,6 +158,13 @@ public abstract class BaseMachineBlockEntity extends BlockEntity implements Cont
     }
     
     /**
+     * Get the energy transfer rate for this machine (can be overridden)
+     */
+    protected int getEnergyTransferRate() {
+        return 1000; // Default 1000 RE/t
+    }
+    
+    /**
      * Try to receive energy from adjacent blocks
      */
     protected void tryReceiveEnergy() {
@@ -171,7 +178,8 @@ public abstract class BaseMachineBlockEntity extends BlockEntity implements Cont
                 if (adjacentEntity != null) {
                     adjacentEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite()).ifPresent(adjacentStorage -> {
                         if (adjacentStorage.canExtract() && energyStorage.canReceive()) {
-                            int energyToReceive = Math.min(energyStorage.getMaxEnergyStored() - energyStorage.getEnergyStored(), 1000);
+                            int transferRate = getEnergyTransferRate();
+                            int energyToReceive = Math.min(energyStorage.getMaxEnergyStored() - energyStorage.getEnergyStored(), transferRate);
                             if (energyToReceive > 0) {
                                 int energyReceived = adjacentStorage.extractEnergy(energyToReceive, false);
                                 if (energyReceived > 0) {
@@ -201,7 +209,8 @@ public abstract class BaseMachineBlockEntity extends BlockEntity implements Cont
                 if (adjacentEntity != null) {
                     adjacentEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite()).ifPresent(adjacentStorage -> {
                         if (adjacentStorage.canReceive() && energyStorage.canExtract()) {
-                            int energyToSend = Math.min(energyStorage.getEnergyStored(), 1000);
+                            int transferRate = getEnergyTransferRate();
+                            int energyToSend = Math.min(energyStorage.getEnergyStored(), transferRate);
                             if (energyToSend > 0) {
                                 int energySent = adjacentStorage.receiveEnergy(energyToSend, false);
                                 if (energySent > 0) {

--- a/src/main/java/com/hexvane/strangematter/block/ParadoxicalEnergyCellBlockEntity.java
+++ b/src/main/java/com/hexvane/strangematter/block/ParadoxicalEnergyCellBlockEntity.java
@@ -52,7 +52,8 @@ public class ParadoxicalEnergyCellBlockEntity extends BlockEntity {
                 adjacentEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite()).ifPresent(adjacentStorage -> {
                     if (adjacentStorage.canReceive()) {
                         // Try to transfer energy
-                        int energyToTransfer = Math.min(1000, adjacentStorage.getMaxEnergyStored() - adjacentStorage.getEnergyStored());
+                        int transferRate = com.hexvane.strangematter.Config.paradoxicalCellTransferRate;
+                        int energyToTransfer = Math.min(transferRate, adjacentStorage.getMaxEnergyStored() - adjacentStorage.getEnergyStored());
                         if (energyToTransfer > 0) {
                             int energyTransferred = adjacentStorage.receiveEnergy(energyToTransfer, false);
                             if (energyTransferred > 0) {

--- a/src/main/java/com/hexvane/strangematter/block/RealityForgeBlockEntity.java
+++ b/src/main/java/com/hexvane/strangematter/block/RealityForgeBlockEntity.java
@@ -39,7 +39,11 @@ public class RealityForgeBlockEntity extends BaseMachineBlockEntity {
     // Crafting state
     private boolean isCrafting = false;
     private int craftTicks = 0;
-    private static final int CRAFT_TIME = 100; // 5 seconds at 20 TPS
+    
+    // Get craft time from config
+    private int getCraftTime() {
+        return com.hexvane.strangematter.Config.realityForgeCraftTime;
+    }
     
     // Visual feedback for coalescing animation (happens during crafting)
     private boolean isCoalescing = false;
@@ -115,7 +119,7 @@ public class RealityForgeBlockEntity extends BaseMachineBlockEntity {
         // Reality Forge specific processing logic
         if (isCrafting) {
             craftTicks++;
-            if (craftTicks >= CRAFT_TIME) {
+            if (craftTicks >= getCraftTime()) {
                 completeCrafting();
             }
         }
@@ -132,7 +136,8 @@ public class RealityForgeBlockEntity extends BaseMachineBlockEntity {
                 blockEntity.setChanged();
             }
 
-            if (blockEntity.craftTicks >= CRAFT_TIME) {
+            int craftTime = blockEntity.getCraftTime();
+            if (blockEntity.craftTicks >= craftTime) {
                 // Double-check that we're still crafting and have a recipe before completing
                 if (blockEntity.isCrafting && blockEntity.currentRecipe != null) {
                     blockEntity.completeCrafting();
@@ -540,7 +545,8 @@ public class RealityForgeBlockEntity extends BaseMachineBlockEntity {
     }
     
     public int getCraftProgress() {
-        return isCrafting ? (craftTicks * 100) / CRAFT_TIME : 0;
+        int craftTime = getCraftTime();
+        return isCrafting ? (craftTicks * 100) / craftTime : 0;
     }
     
     public boolean isCoalescing() {
@@ -548,7 +554,8 @@ public class RealityForgeBlockEntity extends BaseMachineBlockEntity {
     }
     
     public int getCoalesceProgress() {
-        return isCoalescing ? (craftTicks * 100) / CRAFT_TIME : 0;
+        int craftTime = getCraftTime();
+        return isCoalescing ? (craftTicks * 100) / craftTime : 0;
     }
     
     public void dropContents() {

--- a/src/main/java/com/hexvane/strangematter/block/ResearchMachineBlockEntity.java
+++ b/src/main/java/com/hexvane/strangematter/block/ResearchMachineBlockEntity.java
@@ -45,10 +45,22 @@ public class ResearchMachineBlockEntity extends BlockEntity {
         if (com.hexvane.strangematter.item.ResearchNoteItem.isValidResearchNote(researchNote)) {
             currentResearchId = com.hexvane.strangematter.item.ResearchNoteItem.getResearchId(researchNote);
             activeResearchTypes = com.hexvane.strangematter.item.ResearchNoteItem.getResearchTypes(researchNote);
+            playerId = player.getUUID();
+            
+            // Check if minigames are disabled in config
+            if (!com.hexvane.strangematter.Config.enableMinigames) {
+                // Instant unlock - skip minigames entirely
+                if (!level.isClientSide) {
+                    // Use the same completion flow as normal research
+                    handleResearchCompletion();
+                }
+                return true;
+            }
+            
+            // Normal mode - require minigames
             currentState = MachineState.READY;
             instabilityLevel = 0.5f; // Start at halfway
             researchTicks = 0;
-            playerId = player.getUUID();
             setChanged();
             
             // Play insert sound

--- a/src/main/java/com/hexvane/strangematter/block/ResonanceCondenserBlockEntity.java
+++ b/src/main/java/com/hexvane/strangematter/block/ResonanceCondenserBlockEntity.java
@@ -43,9 +43,9 @@ public class ResonanceCondenserBlockEntity extends BaseMachineBlockEntity {
     public ResonanceCondenserBlockEntity(BlockPos pos, BlockState state) {
         super(StrangeMatterMod.RESONANCE_CONDENSER_BLOCK_ENTITY.get(), pos, state, 1);
         
-        // Configure energy system for Resonance Condenser
-        this.energyPerTick = 2;
-        this.maxEnergyStorage = 1000; // Store up to 5000 energy
+        // Configure energy system for Resonance Condenser from config
+        this.energyPerTick = com.hexvane.strangematter.Config.resonanceCondenserEnergyPerTick;
+        this.maxEnergyStorage = com.hexvane.strangematter.Config.resonanceCondenserEnergyStorage;
         this.energyStorage.setCapacity(maxEnergyStorage);
         
         // Configure energy input sides (all sides except front)
@@ -86,7 +86,8 @@ public class ResonanceCondenserBlockEntity extends BaseMachineBlockEntity {
                 }
                 setActive(true);
                 
-                if (this.tickCounter >= 15) {
+                int progressSpeed = com.hexvane.strangematter.Config.resonanceCondenserProgressSpeed;
+                if (this.tickCounter >= progressSpeed) {
                     this.tickCounter = 0;
                     // Progress increases only if an anomaly is found AND we have energy
                     if (progressLevel < maxProgressLevel) {

--- a/src/main/java/com/hexvane/strangematter/block/ResonantBurnerBlockEntity.java
+++ b/src/main/java/com/hexvane/strangematter/block/ResonantBurnerBlockEntity.java
@@ -22,9 +22,9 @@ public class ResonantBurnerBlockEntity extends BaseMachineBlockEntity {
     private int burnDuration = 0;
     private int fuelSlot = 0; // Single fuel slot
     
-    // Energy generation
-    private int energyPerTick = 20; // Generate 20 energy per tick when burning
-    private int maxEnergyStorage = 10000; // Store up to 10,000 energy
+    // Energy generation (now read from config)
+    private int energyPerTick;
+    private int maxEnergyStorage;
     
     // Machine inventory - fuel slot only
     private final NonNullList<ItemStack> items = NonNullList.withSize(1, ItemStack.EMPTY);
@@ -67,9 +67,9 @@ public class ResonantBurnerBlockEntity extends BaseMachineBlockEntity {
     public ResonantBurnerBlockEntity(BlockPos pos, BlockState state) {
         super(StrangeMatterMod.RESONANT_BURNER_BLOCK_ENTITY.get(), pos, state, 1);
         
-        // Configure energy system for Resonant Burner
-        this.energyPerTick = 20;
-        this.maxEnergyStorage = 10000;
+        // Configure energy system for Resonant Burner from config
+        this.energyPerTick = com.hexvane.strangematter.Config.resonantBurnerEnergyPerTick;
+        this.maxEnergyStorage = com.hexvane.strangematter.Config.resonantBurnerEnergyStorage;
         this.energyStorage.setCapacity(maxEnergyStorage);
         
         // Configure energy input sides (all sides by default)
@@ -79,6 +79,11 @@ public class ResonantBurnerBlockEntity extends BaseMachineBlockEntity {
         // Configure energy output sides (all sides for power distribution)
         boolean[] outputSides = {true, true, true, true, true, true};
         this.setEnergyOutputSides(outputSides);
+    }
+    
+    @Override
+    protected int getEnergyTransferRate() {
+        return com.hexvane.strangematter.Config.resonantBurnerTransferRate;
     }
     
     public static void tick(Level level, BlockPos pos, BlockState state, ResonantBurnerBlockEntity blockEntity) {

--- a/src/main/java/com/hexvane/strangematter/client/screen/ResearchMachineScreen.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/ResearchMachineScreen.java
@@ -757,10 +757,15 @@ public class ResearchMachineScreen extends Screen {
         float oldInstability = blockEntity.getInstabilityLevel();
         if (allStable && !anyUnstable) {
             // All minigames are stable, decrease instability
-            blockEntity.setClientInstabilityLevel(Math.max(0.0f, oldInstability - 0.004f));
+            float decreaseRate = (float) com.hexvane.strangematter.Config.instabilityDecreaseRate;
+            blockEntity.setClientInstabilityLevel(Math.max(0.0f, oldInstability - decreaseRate));
         } else if (anyUnstable) {
             // At least one minigame is unstable, increase instability
-            blockEntity.setClientInstabilityLevel(Math.min(1.0f, oldInstability + 0.001f));
+            // More active minigames = SLOWER increase (divide by number of active minigames)
+            int activeMinigameCount = blockEntity.getActiveResearchTypes().size();
+            float baseIncreaseRate = (float) com.hexvane.strangematter.Config.instabilityBaseIncreaseRate;
+            float actualIncreaseRate = activeMinigameCount > 0 ? baseIncreaseRate / activeMinigameCount : baseIncreaseRate;
+            blockEntity.setClientInstabilityLevel(Math.min(1.0f, oldInstability + actualIncreaseRate));
         }
         
         // Instability warning sounds removed per user request

--- a/src/main/java/com/hexvane/strangematter/client/screen/minigames/CognitionMinigame.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/minigames/CognitionMinigame.java
@@ -20,10 +20,17 @@ public class CognitionMinigame extends ResearchMinigame {
     private static final int TOTAL_GRID_SIZE = (SYMBOL_SIZE + GRID_SPACING) * GRID_SIZE - GRID_SPACING; // Total grid size
     
     // Game mechanics
-    private static final int PATTERN_LENGTH = 3; // Always 3 symbols
-    private static final int DISPLAY_DURATION_TICKS = 60; // 3 seconds at 20 TPS
     private static final int PATTERN_REDISPLAY_TICKS = 100; // 5 seconds between pattern displays
     private static final int DRIFT_DELAY_TICKS = 600; // 30 seconds before drift starts
+    
+    // Config-driven getters
+    private int getMatchDuration() {
+        return com.hexvane.strangematter.Config.cognitionMatchDuration;
+    }
+    
+    private int getDifficulty() {
+        return com.hexvane.strangematter.Config.cognitionDifficulty;
+    }
     
     // Enchanting symbols - using more visually distinct runic symbols
     private static final String[] ENCHANTING_SYMBOLS = {
@@ -48,7 +55,6 @@ public class CognitionMinigame extends ResearchMinigame {
     // Sequential pattern display
     private int currentSymbolIndex = 0; // Which symbol in the pattern is currently being shown
     private int symbolDisplayTicks = 0; // How long the current symbol has been displayed
-    private static final int SYMBOL_DISPLAY_DURATION = 20; // 1 second per symbol at 20 TPS
     private Random random = new Random();
     
     // Button states
@@ -90,7 +96,8 @@ public class CognitionMinigame extends ResearchMinigame {
         // Update sequential pattern display
         if (patternDisplayed) {
             symbolDisplayTicks++;
-            if (symbolDisplayTicks >= SYMBOL_DISPLAY_DURATION) {
+            int symbolDuration = getMatchDuration();
+            if (symbolDisplayTicks >= symbolDuration) {
                 // Move to next symbol
                 currentSymbolIndex++;
                 symbolDisplayTicks = 0;
@@ -240,13 +247,15 @@ public class CognitionMinigame extends ResearchMinigame {
         targetPattern.clear();
         playerInput.clear();
         
-        // Generate a random 3-symbol pattern with no duplicates
+        int patternLength = getDifficulty();
+        
+        // Generate a random pattern with no duplicates
         List<Integer> availableSymbols = new ArrayList<>();
         for (int i = 0; i < GRID_SIZE * GRID_SIZE; i++) {
             availableSymbols.add(i);
         }
         
-        for (int i = 0; i < PATTERN_LENGTH; i++) {
+        for (int i = 0; i < patternLength; i++) {
             int randomIndex = random.nextInt(availableSymbols.size());
             int symbol = availableSymbols.remove(randomIndex);
             targetPattern.add(symbol);

--- a/src/main/java/com/hexvane/strangematter/client/screen/minigames/EnergyMinigame.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/minigames/EnergyMinigame.java
@@ -42,10 +42,24 @@ public class EnergyMinigame extends ResearchMinigame {
     // Alignment tracking
     private boolean isAligned = false;
     private int alignmentTicks = 0;
-    private int requiredAlignmentTicks = 100; // 5 seconds at 20 TPS
-    private int driftDelayTicks = 600; // 30 seconds delay before starting to drift
-    private int driftDelay = 100; // 5 seconds before drifting starts
     private int driftTicks = 0;
+    
+    // Config-driven getters
+    private int getRequiredAlignmentTicks() {
+        return com.hexvane.strangematter.Config.energyRequiredAlignmentTicks;
+    }
+    
+    private int getDriftDelayTicks() {
+        return com.hexvane.strangematter.Config.energyDriftDelayTicks;
+    }
+    
+    private double getAmplitudeStep() {
+        return com.hexvane.strangematter.Config.energyAmplitudeStep;
+    }
+    
+    private double getPeriodStep() {
+        return com.hexvane.strangematter.Config.energyPeriodStep;
+    }
     
     // Drift parameters
     private double amplitudeDrift = 0.0;
@@ -316,21 +330,23 @@ public class EnergyMinigame extends ResearchMinigame {
     
     private void adjustValues(int direction) {
         if (amplitudeDialActive) {
-            currentAmplitude += direction * 0.05;
+            double step = getAmplitudeStep();
+            currentAmplitude += direction * step;
             currentAmplitude = Math.max(MIN_AMPLITUDE, Math.min(MAX_AMPLITUDE, currentAmplitude));
             
             // Auto-match if close to target
-            if (Math.abs(currentAmplitude - targetAmplitude) < 0.08) {
+            if (Math.abs(currentAmplitude - targetAmplitude) < step * 1.6) {
                 currentAmplitude = targetAmplitude;
             }
         }
         
         if (periodDialActive) {
-            currentPeriod += direction * 0.05;
+            double step = getPeriodStep();
+            currentPeriod += direction * step;
             currentPeriod = Math.max(MIN_PERIOD, Math.min(MAX_PERIOD, currentPeriod));
             
             // Auto-match if close to target
-            if (Math.abs(currentPeriod - targetPeriod) < 0.08) {
+            if (Math.abs(currentPeriod - targetPeriod) < step * 1.6) {
                 currentPeriod = targetPeriod;
             }
         }
@@ -374,10 +390,12 @@ public class EnergyMinigame extends ResearchMinigame {
                 }
             } else {
                 alignmentTicks++;
-                if (alignmentTicks >= requiredAlignmentTicks) {
+                int requiredTicks = getRequiredAlignmentTicks();
+                if (alignmentTicks >= requiredTicks) {
                     // Been aligned long enough, start drifting
                     driftTicks++;
-                    if (driftTicks >= driftDelayTicks) {
+                    int driftDelay = getDriftDelayTicks();
+                    if (driftTicks >= driftDelay) {
                         applyDrift();
                     }
                     setState(MinigameState.STABLE);

--- a/src/main/java/com/hexvane/strangematter/client/screen/minigames/GravityMinigame.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/minigames/GravityMinigame.java
@@ -40,14 +40,21 @@ public class GravityMinigame extends ResearchMinigame {
     private static final double AUTO_SNAP_THRESHOLD = 0.1; // Auto-snap when within this range of target (30% of total range for more forgiving)
     
     // Equilibrium detection
-    private static final double EQUILIBRIUM_THRESHOLD = 0.15; // Increased from 0.05 to 0.15 for more forgiving stability detection
     private static final double CENTER_POSITION = 0.5; // Center of the tube
+    
+    // Config-driven getters
+    private double getBalanceThreshold() {
+        return com.hexvane.strangematter.Config.gravityBalanceThreshold;
+    }
+    
+    private int getDriftDelayTicks() {
+        return com.hexvane.strangematter.Config.gravityDriftDelayTicks;
+    }
     
     // Stability tracking
     private boolean isInEquilibrium = false;
     private int equilibriumTicks = 0;
     private int requiredEquilibriumTicks = 100; // 5 seconds at 20 TPS
-    private int driftDelayTicks = 600; // 30 seconds delay before starting to drift
     private int driftTicks = 0;
     private boolean isDrifting = false;
     
@@ -99,7 +106,8 @@ public class GravityMinigame extends ResearchMinigame {
     
     private boolean checkEquilibrium() {
         // Check if cube is in the center zone (between the purple lines)
-        return Math.abs(cubePosition - CENTER_POSITION) < EQUILIBRIUM_THRESHOLD;
+        double threshold = getBalanceThreshold();
+        return Math.abs(cubePosition - CENTER_POSITION) < threshold;
     }
     
     private void updatePhysics() {
@@ -231,7 +239,8 @@ public class GravityMinigame extends ResearchMinigame {
             if (equilibriumTicks >= requiredEquilibriumTicks) {
                 // Been in equilibrium long enough, start drift timer
                 driftTicks++;
-                if (driftTicks >= driftDelayTicks && !isDrifting) {
+                int driftDelay = getDriftDelayTicks();
+                if (driftTicks >= driftDelay && !isDrifting) {
                     isDrifting = true;
                 }
             }

--- a/src/main/java/com/hexvane/strangematter/client/screen/minigames/ShadowMinigame.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/minigames/ShadowMinigame.java
@@ -22,8 +22,19 @@ public class ShadowMinigame extends ResearchMinigame {
     private static final double MIN_LIGHT_DISTANCE = 20.0; // Minimum distance from cube
     private static final double MAX_LIGHT_DISTANCE = 50.0; // Maximum distance from cube
     private static final double LIGHT_ANGLE_RANGE = 120.0; // Degrees of side-to-side movement
-    private static final double ALIGNMENT_THRESHOLD = 3.0; // How close shadows need to be for stability
-    private static final int DRIFT_DELAY_TICKS = 600; // Ticks before drift starts
+    
+    // Config-driven getters
+    private double getAlignmentThreshold() {
+        return com.hexvane.strangematter.Config.shadowAlignmentThreshold;
+    }
+    
+    private int getDriftDelayTicks() {
+        return com.hexvane.strangematter.Config.shadowDriftDelayTicks;
+    }
+    
+    private double getRotationStep() {
+        return com.hexvane.strangematter.Config.shadowRotationStep;
+    }
     
     // Textures
     private static final ResourceLocation CUBE_TEXTURE = ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "textures/ui/shadow_cube.png");
@@ -179,7 +190,8 @@ public class ShadowMinigame extends ResearchMinigame {
                 mouseY >= leftButtonY && mouseY < leftButtonY + CONTROL_SIZE) {
                 
                 leftButtonPressed = true;
-                adjustLightAngle(-5.0); // Rotate 5 degrees left
+                double rotStep = -getRotationStep();
+                adjustLightAngle(rotStep); // Rotate left by config step
                 buttonCooldown = BUTTON_COOLDOWN_TICKS;
                 
                 // Play click sound
@@ -194,7 +206,8 @@ public class ShadowMinigame extends ResearchMinigame {
                 mouseY >= rightButtonY && mouseY < rightButtonY + CONTROL_SIZE) {
                 
                 rightButtonPressed = true;
-                adjustLightAngle(5.0); // Rotate 5 degrees right
+                double rotStep = getRotationStep();
+                adjustLightAngle(rotStep); // Rotate right by config step
                 buttonCooldown = BUTTON_COOLDOWN_TICKS;
                 
                 // Play click sound
@@ -326,7 +339,8 @@ public class ShadowMinigame extends ResearchMinigame {
             angleDiff = 360.0 - angleDiff;
         }
         
-        boolean shadowAligned = angleDiff < ALIGNMENT_THRESHOLD && lengthDiff < ALIGNMENT_THRESHOLD;
+        double threshold = getAlignmentThreshold();
+        boolean shadowAligned = angleDiff < threshold && lengthDiff < threshold;
         
         if (shadowAligned) {
             if (!isStable) {
@@ -344,7 +358,8 @@ public class ShadowMinigame extends ResearchMinigame {
     }
     
     private void updateDrift() {
-        if (isStable && stableTicks >= DRIFT_DELAY_TICKS) {
+        int driftDelay = getDriftDelayTicks();
+        if (isStable && stableTicks >= driftDelay) {
             if (!isDrifting) {
                 isDrifting = true;
                 driftTicks = 0;

--- a/src/main/java/com/hexvane/strangematter/client/screen/minigames/SpaceMinigame.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/minigames/SpaceMinigame.java
@@ -17,9 +17,19 @@ public class SpaceMinigame extends ResearchMinigame {
     
     // Warp parameters
     private static final double MAX_WARP = 1.0; // Maximum warp amount
-    private static final double WARP_ADJUSTMENT = 0.05; // How much warp changes per control input
-    private static final double STABILITY_THRESHOLD = 0.1; // How close to 0 warp is considered stable
-    private static final int DRIFT_DELAY_TICKS = 100; // Ticks before drift starts (reduced for more activity)
+    
+    // Config-driven getters
+    private double getWarpAdjustment() {
+        return com.hexvane.strangematter.Config.spaceWarpAdjustment;
+    }
+    
+    private double getStabilityThreshold() {
+        return com.hexvane.strangematter.Config.spaceStabilityThreshold;
+    }
+    
+    private int getDriftDelayTicks() {
+        return com.hexvane.strangematter.Config.spaceDriftDelayTicks;
+    }
     
     // Textures
     private static final ResourceLocation SPACE_IMAGE_TEXTURE = ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "textures/ui/space_image.png");
@@ -132,7 +142,7 @@ public class SpaceMinigame extends ResearchMinigame {
                 mouseY >= controlsY && mouseY < controlsY + CONTROL_SIZE) {
                 
                 leftButtonPressed = true;
-                adjustWarp(-WARP_ADJUSTMENT);
+                adjustWarp(-1.0); // Direction multiplied by config step in adjustWarp()
                 buttonCooldown = BUTTON_COOLDOWN_TICKS;
                 
                 // Play click sound
@@ -147,7 +157,7 @@ public class SpaceMinigame extends ResearchMinigame {
                 mouseY >= controlsY && mouseY < controlsY + CONTROL_SIZE) {
                 
                 rightButtonPressed = true;
-                adjustWarp(WARP_ADJUSTMENT);
+                adjustWarp(1.0); // Direction multiplied by config step in adjustWarp()
                 buttonCooldown = BUTTON_COOLDOWN_TICKS;
                 
                 // Play click sound
@@ -215,7 +225,8 @@ public class SpaceMinigame extends ResearchMinigame {
     
     private void checkStability() {
         // Check if warp is close to target (0.0)
-        boolean warpMatch = Math.abs(warpAmount - targetWarp) < STABILITY_THRESHOLD;
+        double threshold = getStabilityThreshold();
+        boolean warpMatch = Math.abs(warpAmount - targetWarp) < threshold;
         
         if (warpMatch) {
             if (!isStable) {
@@ -233,7 +244,8 @@ public class SpaceMinigame extends ResearchMinigame {
     }
     
     private void updateDrift() {
-        if (isStable && stableTicks >= DRIFT_DELAY_TICKS) {
+        int driftDelay = getDriftDelayTicks();
+        if (isStable && stableTicks >= driftDelay) {
             if (!isDrifting) {
                 isDrifting = true;
                 driftTicks = 0;
@@ -252,7 +264,8 @@ public class SpaceMinigame extends ResearchMinigame {
     }
     
     private void adjustWarp(double adjustment) {
-        warpAmount += adjustment;
+        double step = getWarpAdjustment();
+        warpAmount += adjustment * step;
         warpAmount = Math.max(0.0, Math.min(MAX_WARP, warpAmount));
         
         // Reset drift when actively adjusting

--- a/src/main/java/com/hexvane/strangematter/client/screen/minigames/TimeMinigame.java
+++ b/src/main/java/com/hexvane/strangematter/client/screen/minigames/TimeMinigame.java
@@ -23,9 +23,19 @@ public class TimeMinigame extends ResearchMinigame {
     
     // Speed and timing
     private static final double MAX_SPEED = 2.0; // Maximum speed multiplier
-    private static final double SPEED_ADJUSTMENT = 0.1; // How much speed changes per button press
-    private static final double AUTO_SNAP_THRESHOLD = 0.15; // Auto-snap when within this range of target speed
-    private static final int DRIFT_DELAY_TICKS = 200; // Ticks before drift starts (same as energy minigame)
+    
+    // Config-driven getters
+    private double getSpeedAdjustment() {
+        return com.hexvane.strangematter.Config.timeSpeedAdjustment;
+    }
+    
+    private double getSpeedThreshold() {
+        return com.hexvane.strangematter.Config.timeSpeedThreshold;
+    }
+    
+    private int getDriftDelayTicks() {
+        return com.hexvane.strangematter.Config.timeDriftDelayTicks;
+    }
     
     // Textures
     private static final ResourceLocation CLOCK_TEXTURE = ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "textures/ui/time_clock.png");
@@ -143,7 +153,7 @@ public class TimeMinigame extends ResearchMinigame {
                 mouseY >= buttonY && mouseY < buttonY + BUTTON_SIZE) {
                 
                 leftButtonPressed = true;
-                adjustSpeed(-SPEED_ADJUSTMENT);
+                adjustSpeed(-1.0); // Direction multiplied by config step in adjustSpeed()
                 buttonCooldown = BUTTON_COOLDOWN_TICKS;
                 
                 // Play click sound
@@ -157,7 +167,7 @@ public class TimeMinigame extends ResearchMinigame {
                 mouseY >= buttonY && mouseY < buttonY + BUTTON_SIZE) {
                 
                 rightButtonPressed = true;
-                adjustSpeed(SPEED_ADJUSTMENT);
+                adjustSpeed(1.0); // Direction multiplied by config step in adjustSpeed()
                 buttonCooldown = BUTTON_COOLDOWN_TICKS;
                 
                 // Play click sound
@@ -263,7 +273,8 @@ public class TimeMinigame extends ResearchMinigame {
     
     private void checkStability() {
         // Check if speed is close to target (1.0)
-        boolean speedMatch = Math.abs(clockSpeed - targetSpeed) < AUTO_SNAP_THRESHOLD;
+        double threshold = getSpeedThreshold();
+        boolean speedMatch = Math.abs(clockSpeed - targetSpeed) < threshold;
         
         if (speedMatch) {
             if (!isStable) {
@@ -281,7 +292,8 @@ public class TimeMinigame extends ResearchMinigame {
     }
     
     private void updateDrift() {
-        if (isStable && stableTicks >= DRIFT_DELAY_TICKS) {
+        int driftDelay = getDriftDelayTicks();
+        if (isStable && stableTicks >= driftDelay) {
             if (!isDrifting) {
                 isDrifting = true;
                 driftTicks = 0;
@@ -299,7 +311,8 @@ public class TimeMinigame extends ResearchMinigame {
     }
     
     private void adjustSpeed(double adjustment) {
-        clockSpeed += adjustment;
+        double step = getSpeedAdjustment();
+        clockSpeed += adjustment * step;
         clockSpeed = Math.max(-MAX_SPEED, Math.min(MAX_SPEED, clockSpeed));
         
         // Reset drift when actively adjusting

--- a/src/main/java/com/hexvane/strangematter/entity/BaseAnomalyEntity.java
+++ b/src/main/java/com/hexvane/strangematter/entity/BaseAnomalyEntity.java
@@ -1,5 +1,6 @@
 package com.hexvane.strangematter.entity;
 
+import com.hexvane.strangematter.Config;
 import com.hexvane.strangematter.StrangeMatterMod;
 import com.hexvane.strangematter.research.ScannableObject;
 import com.hexvane.strangematter.research.ScannableObjectRegistry;
@@ -143,9 +144,13 @@ public abstract class BaseAnomalyEntity extends Entity {
     protected abstract ResearchType getResearchType();
     
     /**
-     * Override this method to return the research amount this anomaly provides
+     * Get the research amount this anomaly provides by looking it up from the ScannableObjectRegistry
      */
-    protected abstract int getResearchAmount();
+    protected int getResearchAmount() {
+        return com.hexvane.strangematter.research.ScannableObjectRegistry.getScannableForEntity(this)
+            .map(com.hexvane.strangematter.research.ScannableObject::getResearchAmount)
+            .orElse(0);
+    }
     
     /**
      * Override this method to return the anomaly name for display
@@ -211,8 +216,9 @@ public abstract class BaseAnomalyEntity extends Entity {
                             }
                         }
                         
-                        // Place anomalous grass on suitable surface blocks
-                        if (currentState.is(Blocks.GRASS_BLOCK) || currentState.is(Blocks.DIRT) || 
+                        // Place anomalous grass on suitable surface blocks (if enabled in config)
+                        if (Config.enableAnomalousGrass && 
+                            (currentState.is(Blocks.GRASS_BLOCK) || currentState.is(Blocks.DIRT) || 
                             currentState.is(Blocks.COARSE_DIRT) || currentState.is(Blocks.PODZOL) ||
                             currentState.is(Blocks.SAND) || currentState.is(Blocks.RED_SAND) ||
                             currentState.is(Blocks.TERRACOTTA) || currentState.is(Blocks.WHITE_TERRACOTTA) ||
@@ -224,7 +230,7 @@ public abstract class BaseAnomalyEntity extends Entity {
                             currentState.is(Blocks.BLUE_TERRACOTTA) || currentState.is(Blocks.BROWN_TERRACOTTA) ||
                             currentState.is(Blocks.GREEN_TERRACOTTA) || currentState.is(Blocks.RED_TERRACOTTA) ||
                             currentState.is(Blocks.BLACK_TERRACOTTA) || currentState.is(Blocks.SNOW) ||
-                            currentState.is(Blocks.SNOW_BLOCK)) {
+                            currentState.is(Blocks.SNOW_BLOCK))) {
                             this.level().setBlock(targetPos, StrangeMatterMod.ANOMALOUS_GRASS_BLOCK.get().defaultBlockState(), 3);
                             modifiedBlocks.add(targetPos);
                         }
@@ -236,8 +242,8 @@ public abstract class BaseAnomalyEntity extends Entity {
                         int surfaceY = surfacePos.getY();
                         int oreY = surfaceY - (1 + this.level().getRandom().nextInt(5)); // 1-5 blocks below surface
                         
-                        // Place resonite ore (50% chance)
-                        if (this.level().getRandom().nextFloat() < 0.5f) { // 50% chance
+                        // Place resonite ore (configurable chance)
+                        if (this.level().getRandom().nextFloat() < Config.resoniteOreSpawnChanceNearAnomaly) {
                             BlockPos orePos = new BlockPos(pos.getX(), oreY, pos.getZ());
                             BlockState oreState = this.level().getBlockState(orePos);
                             if (canReplaceWithOre(oreState)) {
@@ -246,8 +252,8 @@ public abstract class BaseAnomalyEntity extends Entity {
                             }
                         }
                         
-                        // Place corresponding shard ore (slightly less frequently than resonite)
-                        if (this.level().getRandom().nextFloat() < 0.2f) { // 20% chance vs 50% for resonite
+                        // Place corresponding shard ore (configurable chance)
+                        if (this.level().getRandom().nextFloat() < Config.shardOreSpawnChanceNearAnomaly) {
                             int shardOreY = surfaceY - (1 + this.level().getRandom().nextInt(5)); // 1-5 blocks below surface
                             BlockPos shardOrePos = new BlockPos(pos.getX(), shardOreY, pos.getZ());
                             BlockState shardOreState = this.level().getBlockState(shardOrePos);
@@ -261,8 +267,8 @@ public abstract class BaseAnomalyEntity extends Entity {
                         int anomalyY = centerPos.getY() - 5;
                         int oreY = anomalyY - (1 + this.level().getRandom().nextInt(5)); // 1-5 blocks below anomaly
                         
-                        // Place resonite ore (50% chance)
-                        if (this.level().getRandom().nextFloat() < 0.5f) { // 50% chance
+                        // Place resonite ore (configurable chance)
+                        if (this.level().getRandom().nextFloat() < Config.resoniteOreSpawnChanceNearAnomaly) {
                             BlockPos orePos = new BlockPos(pos.getX(), oreY, pos.getZ());
                             BlockState oreState = this.level().getBlockState(orePos);
                             if (canReplaceWithOre(oreState)) {
@@ -271,8 +277,8 @@ public abstract class BaseAnomalyEntity extends Entity {
                             }
                         }
                         
-                        // Place corresponding shard ore (slightly less frequently than resonite)
-                        if (this.level().getRandom().nextFloat() < 0.2f) { // 20% chance vs 50% for resonite
+                        // Place corresponding shard ore (configurable chance)
+                        if (this.level().getRandom().nextFloat() < Config.shardOreSpawnChanceNearAnomaly) {
                             int shardOreY = anomalyY - (1 + this.level().getRandom().nextInt(5)); // 1-5 blocks below anomaly
                             BlockPos shardOrePos = new BlockPos(pos.getX(), shardOreY, pos.getZ());
                             BlockState shardOreState = this.level().getBlockState(shardOrePos);

--- a/src/main/java/com/hexvane/strangematter/research/ResearchNodeRegistry.java
+++ b/src/main/java/com/hexvane/strangematter/research/ResearchNodeRegistry.java
@@ -1,5 +1,6 @@
 package com.hexvane.strangematter.research;
 
+import com.hexvane.strangematter.Config;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -13,6 +14,57 @@ public class ResearchNodeRegistry {
     public static void register(ResearchNode node) {
         nodes.put(node.getId(), node);
         nodesByCategory.computeIfAbsent(node.getCategory(), k -> new ArrayList<>()).add(node);
+    }
+    
+    /**
+     * Apply config multiplier and overrides to research costs
+     */
+    private static Map<ResearchType, Integer> applyConfigCosts(String nodeId, Map<ResearchType, Integer> defaultCosts) {
+        if (defaultCosts.isEmpty()) {
+            return defaultCosts; // Don't modify unlocked nodes
+        }
+        
+        // Check for individual override first
+        int overrideCost = getIndividualCostOverride(nodeId);
+        Map<ResearchType, Integer> costs = new HashMap<>(defaultCosts);
+        
+        if (overrideCost > 0) {
+            // Apply individual override - distribute evenly among research types
+            int costPerType = Math.max(1, overrideCost / costs.size());
+            for (ResearchType type : costs.keySet()) {
+                costs.put(type, costPerType);
+            }
+        } else {
+            // Apply global multiplier
+            double multiplier = Config.researchCostMultiplier;
+            for (Map.Entry<ResearchType, Integer> entry : costs.entrySet()) {
+                int newCost = Math.max(1, (int) Math.round(entry.getValue() * multiplier));
+                costs.put(entry.getKey(), newCost);
+            }
+        }
+        
+        return costs;
+    }
+    
+    /**
+     * Get individual cost override for a specific node
+     */
+    private static int getIndividualCostOverride(String nodeId) {
+        return switch (nodeId) {
+            case "anomaly_resonator" -> Config.anomalyResonatorCost;
+            case "resonance_condenser" -> Config.resonanceCondenserCost;
+            case "containment_basics" -> Config.containmentBasicsCost;
+            case "reality_forge" -> Config.realityForgeCost;
+            case "warp_gun" -> Config.warpGunCost;
+            case "stasis_projector" -> Config.stasisProjectorCost;
+            case "gravity_anomalies" -> Config.gravityAnomaliesCost;
+            case "temporal_anomalies" -> Config.temporalAnomaliesCost;
+            case "spatial_anomalies" -> Config.spatialAnomaliesCost;
+            case "energy_anomalies" -> Config.energyAnomaliesCost;
+            case "shadow_anomalies" -> Config.shadowAnomaliesCost;
+            case "cognitive_anomalies" -> Config.cognitiveAnomaliesCost;
+            default -> -1; // Use default
+        };
     }
     
     public static ResearchNode getNode(String id) {
@@ -161,7 +213,7 @@ public class ResearchNodeRegistry {
             "anomaly_resonator",
             "general",
             -160, 0,
-            Map.of(ResearchType.ENERGY, 10, ResearchType.SPACE, 10),
+            applyConfigCosts("anomaly_resonator", Map.of(ResearchType.ENERGY, 10, ResearchType.SPACE, 10)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.ANOMALY_RESONATOR.get()),
             true,
@@ -173,7 +225,7 @@ public class ResearchNodeRegistry {
             "resonance_condenser",
             "general",
             -160, 80,
-            Map.of(ResearchType.ENERGY, 25, ResearchType.SPACE, 15),
+            applyConfigCosts("resonance_condenser", Map.of(ResearchType.ENERGY, 25, ResearchType.SPACE, 15)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.RESONANCE_CONDENSER_ITEM.get()),
             true,
@@ -185,7 +237,7 @@ public class ResearchNodeRegistry {
             "containment_basics",
             "general",
             0, 160,
-            Map.of(ResearchType.ENERGY, 20, ResearchType.SHADOW, 15),
+            applyConfigCosts("containment_basics", Map.of(ResearchType.ENERGY, 20, ResearchType.SHADOW, 15)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.ECHO_VACUUM.get()),
             true,
@@ -197,7 +249,7 @@ public class ResearchNodeRegistry {
             "reality_forge",
             "general",
             -80, 200,
-            Map.of(ResearchType.ENERGY, 5, ResearchType.SPACE, 5, ResearchType.TIME, 5),
+            applyConfigCosts("reality_forge", Map.of(ResearchType.ENERGY, 5, ResearchType.SPACE, 5, ResearchType.TIME, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.REALITY_FORGE_ITEM.get()),
             true,
@@ -209,7 +261,7 @@ public class ResearchNodeRegistry {
             "warp_gun",
             "general",
             -80, 280,
-            Map.of(ResearchType.SPACE, 15, ResearchType.ENERGY, 10),
+            applyConfigCosts("warp_gun", Map.of(ResearchType.SPACE, 15, ResearchType.ENERGY, 10)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.WARP_GUN.get()),
             true,
@@ -221,7 +273,7 @@ public class ResearchNodeRegistry {
             "stasis_projector",
             "general",
             80, 280,
-            Map.of(ResearchType.GRAVITY, 5, ResearchType.TIME, 5),
+            applyConfigCosts("stasis_projector", Map.of(ResearchType.GRAVITY, 5, ResearchType.TIME, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.STASIS_PROJECTOR_ITEM.get()),
             true,
@@ -235,7 +287,7 @@ public class ResearchNodeRegistry {
             "gravity_anomalies",
             "general",
             -80, -160,
-            Map.of(ResearchType.GRAVITY, 5),
+            applyConfigCosts("gravity_anomalies", Map.of(ResearchType.GRAVITY, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.GRAVITIC_SHARD.get()),
             true,
@@ -247,7 +299,7 @@ public class ResearchNodeRegistry {
             "temporal_anomalies",
             "general",
             0, -160,
-            Map.of(ResearchType.TIME, 5),
+            applyConfigCosts("temporal_anomalies", Map.of(ResearchType.TIME, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.CHRONO_SHARD.get()),
             true,
@@ -259,7 +311,7 @@ public class ResearchNodeRegistry {
             "spatial_anomalies",
             "general",
             80, -160,
-            Map.of(ResearchType.SPACE, 5),
+            applyConfigCosts("spatial_anomalies", Map.of(ResearchType.SPACE, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.SPATIAL_SHARD.get()),
             true,
@@ -271,7 +323,7 @@ public class ResearchNodeRegistry {
             "energy_anomalies",
             "general",
             -80, -240,
-            Map.of(ResearchType.ENERGY, 5),
+            applyConfigCosts("energy_anomalies", Map.of(ResearchType.ENERGY, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.ENERGETIC_SHARD.get()),
             true,
@@ -283,7 +335,7 @@ public class ResearchNodeRegistry {
             "shadow_anomalies",
             "general",
             0, -240,
-            Map.of(ResearchType.SHADOW, 5),
+            applyConfigCosts("shadow_anomalies", Map.of(ResearchType.SHADOW, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.SHADE_SHARD.get()),
             true,
@@ -295,7 +347,7 @@ public class ResearchNodeRegistry {
             "cognitive_anomalies",
             "general",
             80, -240,
-            Map.of(ResearchType.COGNITION, 5),
+            applyConfigCosts("cognitive_anomalies", Map.of(ResearchType.COGNITION, 5)),
             ResourceLocation.parse("strangematter:textures/ui/research_gui_node.png"),
             new ItemStack(com.hexvane.strangematter.StrangeMatterMod.INSIGHT_SHARD.get()),
             true,

--- a/src/main/java/com/hexvane/strangematter/research/ScannableObjectRegistry.java
+++ b/src/main/java/com/hexvane/strangematter/research/ScannableObjectRegistry.java
@@ -1,5 +1,6 @@
 package com.hexvane.strangematter.research;
 
+import com.hexvane.strangematter.Config;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -14,30 +15,34 @@ public class ScannableObjectRegistry {
     private static final Map<ResourceLocation, ScannableObject> entityScannables = new HashMap<>();
     private static final Map<ResourceLocation, ScannableObject> blockScannables = new HashMap<>();
     
-    static {
+    /**
+     * Initialize the registry. This is called during mod initialization.
+     * Research points are retrieved from config instead of being hardcoded.
+     */
+    public static void init() {
         // Register gravity anomaly entity
         registerEntity(ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "gravity_anomaly"), 
-            ResearchType.GRAVITY, 10);
+            ResearchType.GRAVITY, Config.gravityResearchPoints);
         
         // Register warp gate anomaly entity
         registerEntity(ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "warp_gate_anomaly"), 
-            ResearchType.SPACE, 10);
+            ResearchType.SPACE, Config.warpResearchPoints);
         
         // Register energetic rift entity
         registerEntity(ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "energetic_rift"), 
-            ResearchType.ENERGY, 10);
+            ResearchType.ENERGY, Config.energeticResearchPoints);
         
         // Register echoing shadow entity
         registerEntity(ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "echoing_shadow"), 
-            ResearchType.SHADOW, 10);
+            ResearchType.SHADOW, Config.shadowResearchPoints);
 
         // Register temporal bloom entity
         registerEntity(ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "temporal_bloom"), 
-        ResearchType.TIME, 10);
+            ResearchType.TIME, Config.temporalResearchPoints);
         
         // Register thoughtwell entity
         registerEntity(ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, "thoughtwell"), 
-            ResearchType.COGNITION, 10);
+            ResearchType.COGNITION, Config.thoughtwellResearchPoints);
     }
     
     public static void registerEntity(ResourceLocation entityType, ResearchType researchType, int amount) {

--- a/src/main/java/com/hexvane/strangematter/worldgen/ConfigurableFeaturePlacement.java
+++ b/src/main/java/com/hexvane/strangematter/worldgen/ConfigurableFeaturePlacement.java
@@ -1,0 +1,74 @@
+package com.hexvane.strangematter.worldgen;
+
+import com.hexvane.strangematter.Config;
+import com.hexvane.strangematter.StrangeMatterMod;
+import org.slf4j.Logger;
+import com.mojang.logging.LogUtils;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
+import net.minecraftforge.event.server.ServerAboutToStartEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.List;
+import java.util.ArrayList;
+
+/**
+ * Handles dynamic modification of world generation features based on config values.
+ * This modifies placed features at server start to respect config settings.
+ */
+@Mod.EventBusSubscriber(modid = StrangeMatterMod.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class ConfigurableFeaturePlacement {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    
+    @SubscribeEvent
+    public static void onServerAboutToStart(ServerAboutToStartEvent event) {
+        Registry<PlacedFeature> placedFeatures = event.getServer()
+                .registryAccess()
+                .registryOrThrow(Registries.PLACED_FEATURE);
+        
+        // Update anomaly spawn rarities based on config
+        updateAnomalyRarity(placedFeatures, "gravity_anomaly", Config.gravityAnomalyRarity, Config.enableGravityAnomaly);
+        updateAnomalyRarity(placedFeatures, "temporal_bloom", Config.temporalBloomRarity, Config.enableTemporalBloom);
+        updateAnomalyRarity(placedFeatures, "warp_gate_anomaly", Config.warpGateRarity, Config.enableWarpGate);
+        updateAnomalyRarity(placedFeatures, "energetic_rift", Config.energeticRiftRarity, Config.enableEnergeticRift);
+        updateAnomalyRarity(placedFeatures, "echoing_shadow", Config.echoingShadowRarity, Config.enableEchoingShadow);
+        updateAnomalyRarity(placedFeatures, "thoughtwell", Config.thoughtwellRarity, Config.enableThoughtwell);
+        
+        // Update resonite ore generation
+        updateOreGeneration(placedFeatures, "resonite_ore", Config.resoniteOreVeinsPerChunk, Config.enableResoniteOre);
+    }
+    
+    private static void updateAnomalyRarity(Registry<PlacedFeature> registry, String featureName, 
+                                           int rarity, boolean enabled) {
+        ResourceKey<PlacedFeature> key = ResourceKey.create(
+                Registries.PLACED_FEATURE,
+                ResourceLocation.fromNamespaceAndPath(StrangeMatterMod.MODID, featureName)
+        );
+        
+        // Note: This is informational logging since Forge's registry is immutable after freezing
+        // The actual modification happens through our custom biome modifier system
+        if (!enabled) {
+            LOGGER.info("Feature {} is disabled in config", featureName);
+        } else if (rarity != 500) { // 500 is the default
+            LOGGER.info("Feature {} rarity changed to 1/{}", featureName, rarity);
+        }
+    }
+    
+    private static void updateOreGeneration(Registry<PlacedFeature> registry, String featureName,
+                                           int veinsPerChunk, boolean enabled) {
+        if (!enabled) {
+            LOGGER.info("Ore feature {} is disabled in config", featureName);
+        } else if (veinsPerChunk != 3) { // 3 is the default
+            LOGGER.info("Ore feature {} veins per chunk changed to {}", featureName, veinsPerChunk);
+        }
+    }
+}
+

--- a/src/main/java/com/hexvane/strangematter/worldgen/ConfiguredBiomeModifier.java
+++ b/src/main/java/com/hexvane/strangematter/worldgen/ConfiguredBiomeModifier.java
@@ -1,0 +1,65 @@
+package com.hexvane.strangematter.worldgen;
+
+import com.hexvane.strangematter.Config;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderSet;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraftforge.common.world.BiomeModifier;
+import net.minecraftforge.common.world.ModifiableBiomeInfo;
+
+/**
+ * A configurable biome modifier that respects config settings for feature placement.
+ * This allows features to be enabled/disabled and their rarity to be adjusted via config.
+ */
+public record ConfiguredBiomeModifier(
+        HolderSet<Biome> biomes,
+        Holder<PlacedFeature> feature,
+        GenerationStep.Decoration step,
+        String featureType  // e.g., "gravity_anomaly", "resonite_ore"
+) implements BiomeModifier {
+    
+    public static final Codec<ConfiguredBiomeModifier> CODEC = RecordCodecBuilder.create(
+        builder -> builder.group(
+            Biome.LIST_CODEC.fieldOf("biomes").forGetter(ConfiguredBiomeModifier::biomes),
+            PlacedFeature.CODEC.fieldOf("feature").forGetter(ConfiguredBiomeModifier::feature),
+            GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ConfiguredBiomeModifier::step),
+            Codec.STRING.fieldOf("feature_type").forGetter(ConfiguredBiomeModifier::featureType)
+        ).apply(builder, ConfiguredBiomeModifier::new)
+    );
+
+    @Override
+    public void modify(Holder<Biome> biome, Phase phase, ModifiableBiomeInfo.BiomeInfo.Builder builder) {
+        if (phase == Phase.ADD && this.biomes.contains(biome)) {
+            // Check config to see if this feature should be added
+            if (isFeatureEnabled()) {
+                builder.getGenerationSettings().addFeature(this.step, this.feature);
+            }
+        }
+    }
+
+    @Override
+    public Codec<? extends BiomeModifier> codec() {
+        return CODEC;
+    }
+    
+    /**
+     * Check config to determine if this feature should be enabled
+     */
+    private boolean isFeatureEnabled() {
+        return switch (featureType) {
+            case "gravity_anomaly" -> Config.enableGravityAnomaly;
+            case "temporal_bloom" -> Config.enableTemporalBloom;
+            case "warp_gate_anomaly" -> Config.enableWarpGate;
+            case "energetic_rift" -> Config.enableEnergeticRift;
+            case "echoing_shadow" -> Config.enableEchoingShadow;
+            case "thoughtwell" -> Config.enableThoughtwell;
+            case "resonite_ore" -> Config.enableResoniteOre;
+            default -> true; // Default to enabled if unknown
+        };
+    }
+}
+

--- a/src/main/java/com/hexvane/strangematter/worldgen/ConfiguredCountPlacement.java
+++ b/src/main/java/com/hexvane/strangematter/worldgen/ConfiguredCountPlacement.java
@@ -1,0 +1,70 @@
+package com.hexvane.strangematter.worldgen;
+
+import com.hexvane.strangematter.Config;
+import com.hexvane.strangematter.StrangeMatterMod;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+
+import java.util.stream.Stream;
+
+/**
+ * A custom count placement modifier that reads its count value from the config.
+ * This allows ore vein counts to be adjusted via configuration.
+ */
+public class ConfiguredCountPlacement extends PlacementModifier {
+    public static final Codec<ConfiguredCountPlacement> CODEC = RecordCodecBuilder.create(
+        instance -> instance.group(
+            Codec.STRING.fieldOf("feature_type").forGetter(filter -> filter.featureType)
+        ).apply(instance, ConfiguredCountPlacement::new)
+    );
+    
+    private final String featureType;
+    
+    public ConfiguredCountPlacement(String featureType) {
+        this.featureType = featureType;
+    }
+    
+    @Override
+    public Stream<BlockPos> getPositions(PlacementContext context, RandomSource random, BlockPos pos) {
+        int count = getCountFromConfig();
+        
+        // If feature is disabled, return empty stream
+        if (!isFeatureEnabled()) {
+            return Stream.empty();
+        }
+        
+        // Generate 'count' number of positions
+        return Stream.generate(() -> pos).limit(count);
+    }
+    
+    @Override
+    public PlacementModifierType<?> type() {
+        return StrangeMatterMod.CONFIGURED_COUNT_PLACEMENT.get();
+    }
+    
+    /**
+     * Get the count value from config based on feature type
+     */
+    private int getCountFromConfig() {
+        return switch (featureType) {
+            case "resonite_ore" -> Config.resoniteOreVeinsPerChunk;
+            default -> 3; // Default count if unknown
+        };
+    }
+    
+    /**
+     * Check if the feature is enabled in config
+     */
+    private boolean isFeatureEnabled() {
+        return switch (featureType) {
+            case "resonite_ore" -> Config.enableResoniteOre;
+            default -> true; // Default to enabled if unknown
+        };
+    }
+}
+

--- a/src/main/java/com/hexvane/strangematter/worldgen/ConfiguredRarityFilter.java
+++ b/src/main/java/com/hexvane/strangematter/worldgen/ConfiguredRarityFilter.java
@@ -1,0 +1,84 @@
+package com.hexvane.strangematter.worldgen;
+
+import com.hexvane.strangematter.Config;
+import com.hexvane.strangematter.StrangeMatterMod;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+
+import java.util.stream.Stream;
+
+/**
+ * A custom rarity filter that reads its rarity value from the config.
+ * This allows anomaly spawn rates to be adjusted via configuration.
+ */
+public class ConfiguredRarityFilter extends PlacementModifier {
+    public static final Codec<ConfiguredRarityFilter> CODEC = RecordCodecBuilder.create(
+        instance -> instance.group(
+            Codec.STRING.fieldOf("feature_type").forGetter(filter -> filter.featureType)
+        ).apply(instance, ConfiguredRarityFilter::new)
+    );
+    
+    private final String featureType;
+    
+    public ConfiguredRarityFilter(String featureType) {
+        this.featureType = featureType;
+    }
+    
+    @Override
+    public Stream<BlockPos> getPositions(PlacementContext context, RandomSource random, BlockPos pos) {
+        int rarity = getRarityFromConfig();
+        
+        // If feature is disabled, return empty stream (no spawns)
+        if (!isFeatureEnabled()) {
+            return Stream.empty();
+        }
+        
+        // Apply rarity filter: 1/N chance
+        if (rarity > 0 && random.nextInt(rarity) == 0) {
+            return Stream.of(pos);
+        }
+        
+        return Stream.empty();
+    }
+    
+    @Override
+    public PlacementModifierType<?> type() {
+        return StrangeMatterMod.CONFIGURED_RARITY_FILTER.get();
+    }
+    
+    /**
+     * Get the rarity value from config based on feature type
+     */
+    private int getRarityFromConfig() {
+        return switch (featureType) {
+            case "gravity_anomaly" -> Config.gravityAnomalyRarity;
+            case "temporal_bloom" -> Config.temporalBloomRarity;
+            case "warp_gate_anomaly" -> Config.warpGateRarity;
+            case "energetic_rift" -> Config.energeticRiftRarity;
+            case "echoing_shadow" -> Config.echoingShadowRarity;
+            case "thoughtwell" -> Config.thoughtwellRarity;
+            default -> 500; // Default rarity if unknown
+        };
+    }
+    
+    /**
+     * Check if the feature is enabled in config
+     */
+    private boolean isFeatureEnabled() {
+        return switch (featureType) {
+            case "gravity_anomaly" -> Config.enableGravityAnomaly;
+            case "temporal_bloom" -> Config.enableTemporalBloom;
+            case "warp_gate_anomaly" -> Config.enableWarpGate;
+            case "energetic_rift" -> Config.enableEnergeticRift;
+            case "echoing_shadow" -> Config.enableEchoingShadow;
+            case "thoughtwell" -> Config.enableThoughtwell;
+            default -> true; // Default to enabled if unknown
+        };
+    }
+}
+

--- a/src/main/java/com/hexvane/strangematter/worldgen/WarpGateAnomalyStructure.java
+++ b/src/main/java/com/hexvane/strangematter/worldgen/WarpGateAnomalyStructure.java
@@ -26,6 +26,16 @@ public class WarpGateAnomalyStructure extends Structure {
 
     @Override
     public Optional<GenerationStub> findGenerationPoint(GenerationContext context) {
+        // Check if warp gates are enabled in config
+        if (!com.hexvane.strangematter.Config.enableWarpGate) {
+            return Optional.empty();
+        }
+        
+        // Apply rarity check
+        if (context.random().nextInt(com.hexvane.strangematter.Config.warpGateRarity) != 0) {
+            return Optional.empty();
+        }
+        
         System.out.println("=== WARP GATE STRUCTURE GENERATION DEBUG ===");
         System.out.println("WarpGate Structure: findGenerationPoint called for chunk " + context.chunkPos());
         System.out.println("WarpGate Structure: Height accessor min/max: " + context.heightAccessor().getMinBuildHeight() + "/" + context.heightAccessor().getMaxBuildHeight());

--- a/src/main/resources/data/strangematter/worldgen/placed_feature/echoing_shadow.json
+++ b/src/main/resources/data/strangematter/worldgen/placed_feature/echoing_shadow.json
@@ -2,8 +2,8 @@
   "feature": "strangematter:echoing_shadow",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 500
+      "type": "strangematter:configured_rarity_filter",
+      "feature_type": "echoing_shadow"
     },
     {
       "type": "minecraft:in_square"

--- a/src/main/resources/data/strangematter/worldgen/placed_feature/energetic_rift.json
+++ b/src/main/resources/data/strangematter/worldgen/placed_feature/energetic_rift.json
@@ -2,8 +2,8 @@
   "feature": "strangematter:energetic_rift",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 500
+      "type": "strangematter:configured_rarity_filter",
+      "feature_type": "energetic_rift"
     },
     {
       "type": "minecraft:in_square"

--- a/src/main/resources/data/strangematter/worldgen/placed_feature/gravity_anomaly.json
+++ b/src/main/resources/data/strangematter/worldgen/placed_feature/gravity_anomaly.json
@@ -2,8 +2,8 @@
   "feature": "strangematter:gravity_anomaly",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 500
+      "type": "strangematter:configured_rarity_filter",
+      "feature_type": "gravity_anomaly"
     },
     {
       "type": "minecraft:in_square"

--- a/src/main/resources/data/strangematter/worldgen/placed_feature/resonite_ore.json
+++ b/src/main/resources/data/strangematter/worldgen/placed_feature/resonite_ore.json
@@ -2,8 +2,8 @@
   "feature": "strangematter:resonite_ore",
   "placement": [
     {
-      "type": "minecraft:count",
-      "count": 3
+      "type": "strangematter:configured_count_placement",
+      "feature_type": "resonite_ore"
     },
     {
       "type": "minecraft:in_square"

--- a/src/main/resources/data/strangematter/worldgen/placed_feature/temporal_bloom.json
+++ b/src/main/resources/data/strangematter/worldgen/placed_feature/temporal_bloom.json
@@ -2,8 +2,8 @@
   "feature": "strangematter:temporal_bloom",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 500
+      "type": "strangematter:configured_rarity_filter",
+      "feature_type": "temporal_bloom"
     },
     {
       "type": "minecraft:in_square"

--- a/src/main/resources/data/strangematter/worldgen/placed_feature/thoughtwell.json
+++ b/src/main/resources/data/strangematter/worldgen/placed_feature/thoughtwell.json
@@ -2,8 +2,8 @@
   "feature": "strangematter:thoughtwell",
   "placement": [
     {
-      "type": "minecraft:rarity_filter",
-      "chance": 400
+      "type": "strangematter:configured_rarity_filter",
+      "feature_type": "thoughtwell"
     },
     {
       "type": "minecraft:in_square"


### PR DESCRIPTION
## [0.1.2] - 2025-10-09

### Added

#### Configuration
- **Comprehensive configuration system** for all major mod features
  - All configuration files are located in `config/strangematter-common.toml`
  - Hot-reloadable configuration with `/reload` command

##### World Generation
- **Anomaly Spawn Rates**
  - Enable/disable individual anomaly types
  - Configure spawn rarity for each anomaly (1 in X chunks)
  - Gravity Anomaly (default: 1/500)
  - Temporal Bloom (default: 1/500)
  - Warp Gate (default: 1/500)
  - Energetic Rift (default: 1/500)
  - Echoing Shadow (default: 1/500)
  - Thoughtwell (default: 1/500)
- **Ore Generation**
  - Enable/disable Resonite ore generation
  - Resonite ore veins per chunk (default: 3)
- **Terrain Modification**
  - Enable/disable Anomalous grass spawning
  - Resonite ore spawn chance near anomalies (default: 15%)
  - Anomaly shard ore spawn rates near anomalies

##### Anomaly Effects
- **Gravity Anomaly**
  - Enable/disable levitation effects
  - Levitation radius (default: 8 blocks)
  - Levitation force strength (default: 0.1)
  - Research points granted when scanned
- **Temporal Bloom**
  - Enable/disable temporal effects
  - Effect radius (default: 8 blocks)
  - Crop growth/de-growth stages (default: ±1-2)
  - Crop effect cooldown (default: 5 seconds)
  - Mob transformation cooldown (default: 10 seconds)
  - Research points granted
- **Energetic Rift**
  - Enable/disable energy effects
  - Zap radius (default: 6 blocks)
  - Lightning rod radius (default: 8 blocks)
  - Zap damage (default: 1.0 hearts)
  - Zap cooldown (default: 2 seconds)
  - Lightning rod cooldown (default: 10 seconds)
  - Research points granted
- **Warp Gate**
  - Enable/disable teleportation effects
  - Teleport radius (default: 2 blocks)
  - Teleport cooldown (default: 5 seconds)
  - Research points granted
- **Echoing Shadow**
  - Enable/disable shadow effects
  - Effect radius
  - Light absorption strength
  - Mob spawn boost multiplier
  - Research points granted
- **Thoughtwell**
  - Enable/disable cognitive effects
  - Effect radius
  - Confusion duration
  - Research points granted

##### Energy System
- **Resonant Burner**
  - Energy generation per tick (default: 20 RE/t)
  - Internal energy storage (default: 10,000 RE)
  - Energy transfer rate to adjacent blocks (default: 1000 RE/t)
- **Resonance Condenser**
  - Energy consumption per tick (default: 2 RE/t)
  - Internal energy storage (default: 1000 RE)
  - Shard generation progress speed (default: 15 ticks)
- **Paradoxical Energy Cell**
  - Energy transfer rate per tick (default: 1000 RE/t)
- **Reality Forge**
  - Crafting time (default: 100 ticks / 5 seconds)

##### Research System
- **Research Costs**
  - Global multiplier for all research node costs
  - Individual cost overrides for each of the 12 locked research nodes:
    - Anomaly Resonator
    - Resonance Condenser
    - Containment Basics
    - Reality Forge
    - Warp Gun
    - Stasis Projector
    - Gravity Anomalies
    - Temporal Anomalies
    - Spatial Anomalies
    - Energy Anomalies
    - Shadow Anomalies
    - Cognitive Anomalies

##### Research Minigames
- **Global Settings**
  - Enable/disable minigame requirement (instant unlock when disabled)
  - Instability mechanics:
    - Decrease rate when all minigames stable (default: 0.004/tick)
    - Base increase rate divided by number of active minigames (default: 0.001/tick)
    - More active minigames = slower instability increase
- **Energy Minigame (Wave Alignment)**
  - Required alignment time (default: 100 ticks / 5 seconds)
  - Drift delay before difficulty increases (default: 600 ticks / 30 seconds)
  - Amplitude adjustment step size (default: 0.05)
  - Period adjustment step size (default: 0.05)
- **Space Minigame (Image Unwarp)**
  - Stability threshold (default: 0.1, lower = harder)
  - Drift delay (default: 100 ticks)
  - Warp adjustment step size (default: 0.05)
- **Time Minigame (Clock Speed Matching)**
  - Speed difference threshold for stability (default: 0.15)
  - Drift delay (default: 200 ticks)
  - Speed adjustment step size (default: 0.1)
- **Gravity Minigame (Balance Scale)**
  - Balance threshold for stability (default: 0.1)
  - Drift delay (default: 200 ticks)
  - Uses continuous slider (no step adjustment)
- **Shadow Minigame (Light Routing)**
  - Alignment threshold for stability (default: 10.0)
  - Drift delay (default: 200 ticks)
  - Mirror rotation step size (default: 15 degrees)
- **Cognition Minigame (Symbol Matching)**
  - Symbol display duration (default: 100 ticks / 5 seconds)
  - Number of symbols to match (default: 4, range: 2-8)